### PR TITLE
Add browser warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
 		"update-browserslist-db": "1.2.3",
 		"wrangler": "4.85.0"
 	},
+	"browserslist": [
+		"last 2 Chrome versions"
+	],
 	"devEngines": {
 		"runtime": {
 			"name": "node",

--- a/src/components/BrowserWarning.astro
+++ b/src/components/BrowserWarning.astro
@@ -1,0 +1,19 @@
+<script>
+	const ua = navigator.userAgent;
+	const isChrome = /Chrome\/(\d+)/.test(ua);
+	const chromeVersion = isChrome
+		? parseInt(ua.match(/Chrome\/(\d+)/)?.[1] ?? "0", 10)
+		: 0;
+	const minVersion = 120;
+
+	if (!isChrome || chromeVersion < minVersion) {
+		const banner = document.createElement("div");
+		banner.className =
+			"grid grid-cols-[1fr_auto] gap-4 items-center bg-yellow-500 text-black px-4 py-2 text-sm";
+		banner.innerHTML = `
+				<span>Your browser is not fully supported. For the best experience, please use the latest version of Chrome.</span>
+				<button onclick="this.parentElement.remove()" class="hover:opacity-70">✕</button>
+			`;
+		document.body.insertBefore(banner, document.body.firstChild);
+	}
+</script>

--- a/src/layouts/Shell.astro
+++ b/src/layouts/Shell.astro
@@ -1,5 +1,7 @@
 ---
 import "../styles/global.css";
+import BrowserWarning from "../components/BrowserWarning.astro";
+
 const lang = Astro.currentLocale;
 ---
 
@@ -20,5 +22,8 @@ const lang = Astro.currentLocale;
 		<slot name="head" />
 		<link rel="sitemap" href="/sitemap-index.xml">
 	</head>
-	<slot name="body" />
+	<body>
+		<BrowserWarning />
+		<slot name="body" />
+	</body>
 </html>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dismissible browser warning for users on non‑Chrome or Chrome <120, shown across all pages. Updates `browserslist` to target the last 2 Chrome versions.

- **New Features**
  - Introduced `BrowserWarning` that checks UA and injects a top-of-page banner with a close button.
  - Mounted in `Shell.astro` so it runs on every page.

<sup>Written for commit 9762873f8daa9ebcf4d03c51144d5a8d2a016c20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a browser compatibility warning banner for users on older Chrome versions. The banner displays a notification message with a dismissible close button for improved user experience across different browser environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->