### PR TITLE
Add org yearly budget

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,6 @@
 	"[astro]": {
 		"editor.defaultFormatter": "biomejs.biome"
 	},
-	"astro.content-intellisense": true
+	"astro.content-intellisense": true,
+	"typescript.native-preview.tsdk": "/Users/alexanderniebuhr/.local/share/opencode/worktree/f43b9dc2280f61a81ba6c41046870951c79cc77b/brave-eagle/node_modules/@typescript/native-preview"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,5 @@
 	"[astro]": {
 		"editor.defaultFormatter": "biomejs.biome"
 	},
-	"astro.content-intellisense": true,
-	"typescript.native-preview.tsdk": "/Users/alexanderniebuhr/.local/share/opencode/worktree/f43b9dc2280f61a81ba6c41046870951c79cc77b/brave-eagle/node_modules/@typescript/native-preview"
+	"astro.content-intellisense": true
 }

--- a/drizzle/20260426230922_flippant_blizzard/migration.sql
+++ b/drizzle/20260426230922_flippant_blizzard/migration.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `organization_metadata` (
+	`id` text PRIMARY KEY,
+	`organization_id` text NOT NULL,
+	`yearly_budget` integer,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	CONSTRAINT `fk_organization_metadata_organization_id_organization_id_fk` FOREIGN KEY (`organization_id`) REFERENCES `organization`(`id`) ON DELETE CASCADE
+);
+--> statement-breakpoint
+ALTER TABLE `project` ADD `budget` integer;--> statement-breakpoint
+CREATE UNIQUE INDEX `organization_metadata_organization_id_idx` ON `organization_metadata` (`organization_id`);

--- a/drizzle/20260426230922_flippant_blizzard/snapshot.json
+++ b/drizzle/20260426230922_flippant_blizzard/snapshot.json
@@ -1,0 +1,1122 @@
+{
+	"version": "7",
+	"dialect": "sqlite",
+	"id": "006b1f9f-dcff-4bb1-8a4c-0f914fde32e7",
+	"prevIds": ["1167344f-8a3b-4632-a4c7-0f84ab466e3e"],
+	"ddl": [
+		{
+			"name": "account",
+			"entityType": "tables"
+		},
+		{
+			"name": "invitation",
+			"entityType": "tables"
+		},
+		{
+			"name": "member",
+			"entityType": "tables"
+		},
+		{
+			"name": "organization",
+			"entityType": "tables"
+		},
+		{
+			"name": "organization_metadata",
+			"entityType": "tables"
+		},
+		{
+			"name": "project",
+			"entityType": "tables"
+		},
+		{
+			"name": "rate_limit",
+			"entityType": "tables"
+		},
+		{
+			"name": "session",
+			"entityType": "tables"
+		},
+		{
+			"name": "user",
+			"entityType": "tables"
+		},
+		{
+			"name": "verification",
+			"entityType": "tables"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "account_id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "provider_id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "access_token",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "refresh_token",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "access_token_expires_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "refresh_token_expires_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "scope",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id_token",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "password",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "email",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "inviter_id",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "role",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "status",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "role",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "slug",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "logo",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "metadata",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "organization"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "organization_metadata"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "organization_metadata"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "yearly_budget",
+			"entityType": "columns",
+			"table": "organization_metadata"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "organization_metadata"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "organization_metadata"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "project"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "project"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "project"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "budget",
+			"entityType": "columns",
+			"table": "project"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "project"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "rate_limit"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "key",
+			"entityType": "columns",
+			"table": "rate_limit"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "count",
+			"entityType": "columns",
+			"table": "rate_limit"
+		},
+		{
+			"type": "blob",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_request",
+			"entityType": "columns",
+			"table": "rate_limit"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "token",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "ip_address",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_agent",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "active_organization_id",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "active_team_id",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "impersonated_by",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "email",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "email_verified",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "image",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "role",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "banned",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "ban_reason",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "ban_expires",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "identifier",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "value",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "user",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "fk_account_user_id_user_id_fk",
+			"entityType": "fks",
+			"table": "account"
+		},
+		{
+			"columns": ["inviter_id"],
+			"tableTo": "user",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "fk_invitation_inviter_id_user_id_fk",
+			"entityType": "fks",
+			"table": "invitation"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "fk_invitation_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "invitation"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "user",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "fk_member_user_id_user_id_fk",
+			"entityType": "fks",
+			"table": "member"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "fk_member_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "member"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "fk_organization_metadata_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "organization_metadata"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "organization",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "fk_project_organization_id_organization_id_fk",
+			"entityType": "fks",
+			"table": "project"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "user",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "fk_session_user_id_user_id_fk",
+			"entityType": "fks",
+			"table": "session"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "account_pk",
+			"table": "account",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "invitation_pk",
+			"table": "invitation",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "member_pk",
+			"table": "member",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "organization_pk",
+			"table": "organization",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "organization_metadata_pk",
+			"table": "organization_metadata",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "project_pk",
+			"table": "project",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "rate_limit_pk",
+			"table": "rate_limit",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "session_pk",
+			"table": "session",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "user_pk",
+			"table": "user",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "verification_pk",
+			"table": "verification",
+			"entityType": "pks"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "account_user_id_idx",
+			"entityType": "indexes",
+			"table": "account"
+		},
+		{
+			"columns": [
+				{
+					"value": "email",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "invitation_email_idx",
+			"entityType": "indexes",
+			"table": "invitation"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "invitation_organization_id_idx",
+			"entityType": "indexes",
+			"table": "invitation"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "member_user_id_idx",
+			"entityType": "indexes",
+			"table": "member"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "member_organization_id_idx",
+			"entityType": "indexes",
+			"table": "member"
+		},
+		{
+			"columns": [
+				{
+					"value": "slug",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "organization_slug_idx",
+			"entityType": "indexes",
+			"table": "organization"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "organization_metadata_organization_id_idx",
+			"entityType": "indexes",
+			"table": "organization_metadata"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "project_organization_id_idx",
+			"entityType": "indexes",
+			"table": "project"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "session_user_id_idx",
+			"entityType": "indexes",
+			"table": "session"
+		},
+		{
+			"columns": [
+				{
+					"value": "token",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "session_token_idx",
+			"entityType": "indexes",
+			"table": "session"
+		},
+		{
+			"columns": [
+				{
+					"value": "email",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "user_email_idx",
+			"entityType": "indexes",
+			"table": "user"
+		},
+		{
+			"columns": [
+				{
+					"value": "identifier",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "verification_identifier_idx",
+			"entityType": "indexes",
+			"table": "verification"
+		},
+		{
+			"columns": ["key"],
+			"nameExplicit": false,
+			"name": "rate_limit_key_unique",
+			"entityType": "uniques",
+			"table": "rate_limit"
+		}
+	],
+	"renames": []
+}

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -128,7 +128,7 @@ export const server = {
 			yearlyBudget: z.coerce
 				.number()
 				.int()
-				.min(0, "Budget must be a positive number.")
+				.min(0, "Budget must be a non-negative number.")
 				.optional(),
 		}),
 		handler: async ({ organizationId, yearlyBudget }, context) => {

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -134,31 +134,22 @@ export const server = {
 		handler: async ({ organizationId, yearlyBudget }, context) => {
 			await assertOrganizationMember(context.request.headers, organizationId);
 
-			const existing = await db.query.organizationMetadata.findFirst({
-				where: {
-					organizationId,
-				},
-			});
-
-			if (existing) {
-				await db
-					.update(organizationMetadata)
-					.set({
-						yearlyBudget: yearlyBudget ?? null,
-						updatedAt: sql`(cast(unixepoch('subsecond') * 1000 as integer))`,
-					})
-					.where(eq(organizationMetadata.id, existing.id));
-
-				return { id: existing.id };
-			}
-
 			const id = crypto.randomUUID();
 
-			await db.insert(organizationMetadata).values({
-				id,
-				organizationId,
-				yearlyBudget: yearlyBudget ?? null,
-			});
+			await db
+				.insert(organizationMetadata)
+				.values({
+					id,
+					organizationId,
+					yearlyBudget: yearlyBudget ?? null,
+				})
+				.onConflictDoUpdate({
+					target: organizationMetadata.organizationId,
+					set: {
+						yearlyBudget: yearlyBudget ?? null,
+						updatedAt: sql`(cast(unixepoch('subsecond') * 1000 as integer))`,
+					},
+				});
 
 			return { id };
 		},

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,9 +1,9 @@
 import { ActionError, defineAction } from "astro:actions";
 import { z } from "astro/zod";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { auth } from "../lib/auth.ts";
 import { db } from "../lib/database.ts";
-import { project } from "../lib/schema.ts";
+import { organizationMetadata, project } from "../lib/schema.ts";
 
 const assertAdmin = async (headers: Headers) => {
 	const session = await auth.api.getSession({ headers });
@@ -19,6 +19,36 @@ const assertAdmin = async (headers: Headers) => {
 		throw new ActionError({
 			code: "FORBIDDEN",
 			message: "Only admins can manage projects.",
+		});
+	}
+
+	return session;
+};
+
+const assertOrganizationMember = async (
+	headers: Headers,
+	organizationId: string,
+) => {
+	const session = await auth.api.getSession({ headers });
+
+	if (!session) {
+		throw new ActionError({
+			code: "UNAUTHORIZED",
+			message: "Sign in to manage organization.",
+		});
+	}
+
+	const member = await db.query.member.findFirst({
+		where: {
+			userId: session.user.id,
+			organizationId,
+		},
+	});
+
+	if (!member) {
+		throw new ActionError({
+			code: "FORBIDDEN",
+			message: "You are not a member of this organization.",
 		});
 	}
 
@@ -89,6 +119,48 @@ export const server = {
 			await db.delete(project).where(eq(project.id, projectId));
 
 			return { id: projectId };
+		},
+	}),
+	updateOrganizationMetadata: defineAction({
+		accept: "form",
+		input: z.object({
+			organizationId: z.string().trim().min(1, "Choose an organization."),
+			yearlyBudget: z.coerce
+				.number()
+				.int()
+				.min(0, "Budget must be a positive number.")
+				.optional(),
+		}),
+		handler: async ({ organizationId, yearlyBudget }, context) => {
+			await assertOrganizationMember(context.request.headers, organizationId);
+
+			const existing = await db.query.organizationMetadata.findFirst({
+				where: {
+					organizationId,
+				},
+			});
+
+			if (existing) {
+				await db
+					.update(organizationMetadata)
+					.set({
+						yearlyBudget: yearlyBudget ?? null,
+						updatedAt: sql`(cast(unixepoch('subsecond') * 1000 as integer))`,
+					})
+					.where(eq(organizationMetadata.id, existing.id));
+
+				return { id: existing.id };
+			}
+
+			const id = crypto.randomUUID();
+
+			await db.insert(organizationMetadata).values({
+				id,
+				organizationId,
+				yearlyBudget: yearlyBudget ?? null,
+			});
+
+			return { id };
 		},
 	}),
 };

--- a/src/lib/relations.ts
+++ b/src/lib/relations.ts
@@ -9,9 +9,19 @@ export const relations = defineRelations(schema, (r) => ({
 		}),
 	},
 	organization: {
+		orgMetadata: r.one.organizationMetadata({
+			from: r.organization.id,
+			to: r.organizationMetadata.organizationId,
+		}),
 		projects: r.many.project({
 			from: r.organization.id,
 			to: r.project.organizationId,
+		}),
+	},
+	organizationMetadata: {
+		organization: r.one.organization({
+			from: r.organizationMetadata.organizationId,
+			to: r.organization.id,
 		}),
 	},
 	project: {

--- a/src/lib/relations.ts
+++ b/src/lib/relations.ts
@@ -9,7 +9,7 @@ export const relations = defineRelations(schema, (r) => ({
 		}),
 	},
 	organization: {
-		orgMetadata: r.one.organizationMetadata({
+		metadata: r.one.organizationMetadata({
 			from: r.organization.id,
 			to: r.organizationMetadata.organizationId,
 		}),

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -158,10 +158,36 @@ export const project = sqliteTable(
 			.notNull()
 			.references(() => organization.id, { onDelete: "cascade" }),
 		name: t.text("name").notNull(),
+		budget: t.integer("budget"),
 		createdAt: t
 			.integer("created_at", { mode: "timestamp_ms" })
 			.notNull()
 			.default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`),
 	},
 	(table) => [t.index("project_organization_id_idx").on(table.organizationId)],
+);
+
+export const organizationMetadata = sqliteTable(
+	"organization_metadata",
+	{
+		id: t.text("id").primaryKey(),
+		organizationId: t
+			.text("organization_id")
+			.notNull()
+			.references(() => organization.id, { onDelete: "cascade" }),
+		yearlyBudget: t.integer("yearly_budget"),
+		createdAt: t
+			.integer("created_at", { mode: "timestamp_ms" })
+			.notNull()
+			.default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`),
+		updatedAt: t
+			.integer("updated_at", { mode: "timestamp_ms" })
+			.notNull()
+			.default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`),
+	},
+	(table) => [
+		t
+			.uniqueIndex("organization_metadata_organization_id_idx")
+			.on(table.organizationId),
+	],
 );

--- a/src/pages/dash/org/[slug].astro
+++ b/src/pages/dash/org/[slug].astro
@@ -68,10 +68,7 @@ const metadata = organization
 		})
 	: null;
 
-const totalBudget = projects.reduce(
-	(sum, projectRecord) => sum + (projectRecord.budget ?? 0),
-	0,
-);
+const totalBudget = metadata?.yearlyBudget ?? 0;
 ---
 
 <Shell>
@@ -107,14 +104,6 @@ const totalBudget = projects.reduce(
 					>
 						Yearly Budget
 					</h2>
-					{!isInputError(updateMetadataResult?.error) && (
-						<p
-							role="alert"
-							class="border border-dashed border-red-300 dark:border-red-900 bg-red-50 dark:bg-red-950/40 px-3 py-2 text-sm text-red-700 dark:text-red-300"
-						>
-							Unable to update budget. Please try again later.
-						</p>
-					)}
 					<form
 						method="post"
 						action={actions.updateOrganizationMetadata}

--- a/src/pages/dash/org/[slug].astro
+++ b/src/pages/dash/org/[slug].astro
@@ -107,7 +107,7 @@ const totalBudget = projects.reduce(
 					>
 						Yearly Budget
 					</h2>
-					{updateMetadataResult?.error && (
+					{!isInputError(updateMetadataResult?.error) && (
 						<p
 							role="alert"
 							class="border border-dashed border-red-300 dark:border-red-900 bg-red-50 dark:bg-red-950/40 px-3 py-2 text-sm text-red-700 dark:text-red-300"

--- a/src/pages/dash/org/[slug].astro
+++ b/src/pages/dash/org/[slug].astro
@@ -1,6 +1,7 @@
 ---
 export const prerender = false;
 
+import { actions, isInputError } from "astro:actions";
 import { isAPIError } from "better-auth/api";
 import LogoWithTextVertical from "../../../assets/logoWithTextVertical.svg";
 import Footer from "../../../components/Footer.astro";
@@ -42,13 +43,35 @@ const organization = await auth.api.getFullOrganization({
 	headers: Astro.request.headers,
 });
 
+const updateMetadataResult = Astro.getActionResult(
+	actions.updateOrganizationMetadata,
+);
+const metadataInputErrors = isInputError(updateMetadataResult?.error)
+	? updateMetadataResult.error.fields
+	: {};
+
+if (updateMetadataResult && !updateMetadataResult.error) {
+	return Astro.redirect(`/dash/org/${slug}`, 303);
+}
+
 const projects = organization
 	? await db.query.project.findMany({
-			columns: { id: true, name: true },
+			columns: { id: true, name: true, budget: true },
 			where: { organizationId: organization.id },
 			orderBy: { name: "asc" },
 		})
 	: [];
+
+const metadata = organization
+	? await db.query.organizationMetadata.findFirst({
+			where: { organizationId: organization.id },
+		})
+	: null;
+
+const totalBudget = projects.reduce(
+	(sum, projectRecord) => sum + (projectRecord.budget ?? 0),
+	0,
+);
 ---
 
 <Shell>
@@ -78,6 +101,55 @@ const projects = organization
 					</h1>
 				</section>
 
+				<section class="grid content-start gap-3">
+					<h2
+						class="text-sm font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400"
+					>
+						Yearly Budget
+					</h2>
+					{updateMetadataResult?.error && (
+						<p
+							role="alert"
+							class="border border-dashed border-red-300 dark:border-red-900 bg-red-50 dark:bg-red-950/40 px-3 py-2 text-sm text-red-700 dark:text-red-300"
+						>
+							Unable to update budget. Please try again later.
+						</p>
+					)}
+					<form
+						method="post"
+						action={actions.updateOrganizationMetadata}
+						class="grid grid-cols-[1fr_auto] gap-3 items-center"
+					>
+						<input type="hidden" name="organizationId" value={organization?.id}>
+						<input
+							type="number"
+							name="yearlyBudget"
+							min="0"
+							step="1"
+							placeholder="Enter yearly budget"
+							value={metadata?.yearlyBudget ?? ""}
+							aria-describedby={metadataInputErrors.yearlyBudget
+								? "yearly-budget-error"
+								: undefined}
+							class="bg-transparent border border-neutral-300 dark:border-neutral-700 px-3 py-2 text-sm outline-none focus:border-cyan-500 transition-colors placeholder:text-neutral-400 dark:placeholder:text-neutral-600"
+						>
+						<button
+							type="submit"
+							class="px-3 py-2 border transition-colors border-dashed rounded cursor-pointer border-neutral-200 hover:bg-neutral-200 hover:border-neutral-400 text-neutral-900 dark:border-neutral-800 dark:hover:bg-neutral-800 dark:hover:border-neutral-600 dark:text-neutral-100"
+						>
+							Save
+						</button>
+						{metadataInputErrors.yearlyBudget && (
+							<p
+								id="yearly-budget-error"
+								class="col-span-2 text-sm text-red-700 dark:text-red-300"
+							>
+								{metadataInputErrors.yearlyBudget.join(", ")}
+							</p>
+						)}
+					</form>
+				</section>
+
 				<section
 					aria-labelledby="projects-list-heading"
 					class="grid content-start gap-3"
@@ -95,12 +167,22 @@ const projects = organization
 									<article class="grid gap-1">
 										<h3 class="font-semibold">{projectRecord.name}</h3>
 									</article>
+									{projectRecord.budget != null && (
+										<p class="text-sm text-neutral-600 dark:text-neutral-400">
+											{projectRecord.budget.toLocaleString()} €
+										</p>
+									)}
 								</li>
 							))}
 						</ul>
 					) : (
 						<p class="border border-dashed border-neutral-200 dark:border-neutral-800 p-4 text-sm text-neutral-600 dark:text-neutral-400">
 							No projects yet.
+						</p>
+					)}
+					{totalBudget > 0 && (
+						<p class="border-t border-dashed border-neutral-200 dark:border-neutral-800 pt-3 text-sm font-semibold text-neutral-700 dark:text-neutral-300">
+							Total budget: {totalBudget.toLocaleString()} €
 						</p>
 					)}
 				</section>


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/craftlions/website/pull/52" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an organization-level yearly budget with an editable UI and backend storage. Also adds per-project budgets and shows each value and the org’s total yearly budget on the dashboard.

- **New Features**
  - New `organization_metadata` table with `yearly_budget` (unique per org, cascade on delete).
  - Astro action `updateOrganizationMetadata` with member access, validation, upsert on `organization_id`, and `updated_at` tracking.
  - Added `budget` to `project`; display per-project budgets and the org total on `/dash/org/[slug]`.
  - Added relations between `organization` and `organization_metadata`.
  - Inline field errors via `isInputError` and redirect after save.

- **Migration**
  - Run the new Drizzle migration.
  - Optional: backfill `organization_metadata.yearly_budget` and `project.budget` as needed (both nullable).

<sup>Written for commit 290cd39670edc5acca32e5fa467b7d1df858012c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

