### PR TITLE
Add EventTimeline component and surface recent events on org and project pages

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  better-auth@1.6.9: c37aec5d96f647ffb91312ccd1835dbdc5abb5abc7d20119ff9face4e5442a5e
+  better-auth@1.6.9:
+    hash: c37aec5d96f647ffb91312ccd1835dbdc5abb5abc7d20119ff9face4e5442a5e
+    path: patches/better-auth@1.6.9.patch
 
 importers:
 
@@ -121,28 +123,24 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@astrojs/compiler-binding-linux-arm64-musl@0.1.10':
     resolution: {integrity: sha512-ot1Lksml0FqrrlYa89wGXQM+n290ncj65PZAq8siEWmXsmwoNCYCbqRSwRO6I/cT+PDlmmV0AcFTrp1DEO3PUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@astrojs/compiler-binding-linux-x64-gnu@0.1.10':
     resolution: {integrity: sha512-RGKGCbCvDat+DppnQbiWIhif6ptvkyXMdqOa7NjES4UoqIIUjE3YZfRn8gp3bXUe4ReWv4hGO1TQd2eitONt1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@astrojs/compiler-binding-linux-x64-musl@0.1.10':
     resolution: {integrity: sha512-UemMv5Xq9c7trG9Cel4MHAo2wYiCxZ6qIKUnI4NJqBXDtOBqAjcMoqMbw78KYkb9vg2OIewVaJ+YvQrFZs5VBg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@astrojs/compiler-binding-wasm32-wasi@0.1.10':
     resolution: {integrity: sha512-SwawjgiYnm7s5neVKRoHIsnGG06vhuFhKg0iMBO6EsnL19xVbUp61V50gVtdgFlsfXalfH6SHuv2wQw8FhFSNg==}
@@ -503,28 +501,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.14':
     resolution: {integrity: sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.14':
     resolution: {integrity: sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.14':
     resolution: {integrity: sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.14':
     resolution: {integrity: sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA==}
@@ -1150,105 +1144,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1423,42 +1401,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -1574,28 +1546,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
     resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
     resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.4':
     resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.4':
     resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
@@ -2498,28 +2466,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}

--- a/src/components/EventTimeline.astro
+++ b/src/components/EventTimeline.astro
@@ -1,0 +1,44 @@
+---
+type TimelineEvent = {
+	id: string;
+	label: string;
+	detail: string;
+	recordedAt: Date;
+};
+
+type Props = {
+	title: string;
+	events: TimelineEvent[];
+};
+
+const { title, events } = Astro.props as Props;
+
+const dateTimeFormatter = new Intl.DateTimeFormat("de-DE", {
+	dateStyle: "medium",
+	timeStyle: "short",
+});
+---
+
+<section class="grid gap-3" aria-label={title}>
+	<h2
+		class="text-sm font-semibold uppercase text-neutral-500 dark:text-neutral-400"
+		>{title}</h2
+	>
+	{events.length > 0 ? (
+		<ol class="grid gap-3 border border-dashed border-neutral-300 p-4 dark:border-neutral-700">
+			{events.map((event) => (
+				<li class="grid gap-1 border-l border-dashed border-neutral-300 pl-3 dark:border-neutral-700">
+					<p class="text-sm font-semibold">{event.label}</p>
+					<p class="text-xs text-neutral-600 dark:text-neutral-300">{event.detail}</p>
+					<time class="text-xs tabular-nums text-neutral-500 dark:text-neutral-400" datetime={event.recordedAt.toISOString()}>
+						{dateTimeFormatter.format(event.recordedAt)}
+					</time>
+				</li>
+			))}
+		</ol>
+	) : (
+		<p class="border border-dashed border-neutral-300 p-4 text-sm text-neutral-600 dark:border-neutral-700 dark:text-neutral-300">
+			No events recorded yet.
+		</p>
+	)}
+</section>

--- a/src/pages/dash/org/[slug].astro
+++ b/src/pages/dash/org/[slug].astro
@@ -3,13 +3,14 @@ export const prerender = false;
 
 import { actions } from "astro:actions";
 import { isAPIError } from "better-auth/api";
-import { and, asc, eq, gte, inArray, lt, sum } from "drizzle-orm";
+import { and, asc, eq, gte, inArray, lt, or, sum } from "drizzle-orm";
 import Button from "../../../components/Button.astro";
+import EventTimeline from "../../../components/EventTimeline.astro";
 import Footer from "../../../components/Footer.astro";
 import Nav from "../../../components/Nav.astro";
 import OrganizationInvoices from "../../../components/OrganizationInvoices.astro";
 import Shell from "../../../layouts/Shell.astro";
-import { invoice, milestone, project } from "../../../lib/schema.ts";
+import { event, invoice, member, milestone, project } from "../../../lib/schema.ts";
 
 const { slug } = Astro.params;
 
@@ -96,6 +97,49 @@ const yearlyBudget = metadata?.yearlyBudget ?? 0;
 const budgetUsagePercentage =
 	yearlyBudget > 0 ? (totalInvoicedAmount / yearlyBudget) * 100 : 0;
 
+const organizationMemberIds = await Astro.locals.db
+	.select({ userId: member.userId })
+	.from(member)
+	.where(eq(member.organizationId, organization.id))
+	.then((rows) => rows.map((row) => row.userId));
+
+const organizationTimeline = await Astro.locals.db.query.event
+	.findMany({
+		columns: {
+			id: true,
+			aggregateType: true,
+			eventType: true,
+			recordedAt: true,
+			actorType: true,
+			actorId: true,
+		},
+		where:
+			organizationMemberIds.length > 0
+				? or(
+						and(
+							eq(event.actorType, "organization"),
+							eq(event.actorId, organization.id),
+						),
+						and(
+							eq(event.actorType, "user"),
+							inArray(event.actorId, organizationMemberIds),
+						),
+					)
+				: and(eq(event.actorType, "organization"), eq(event.actorId, organization.id)),
+		orderBy: {
+			recordedAt: "desc",
+		},
+		limit: 10,
+	})
+	.then((rows) =>
+		rows.map((row) => ({
+			id: row.id,
+			label: `${row.aggregateType} · ${row.eventType}`.replaceAll("_", " "),
+			detail: `${row.actorType}: ${row.actorId}`,
+			recordedAt: row.recordedAt,
+		})),
+	);
+
 const currencyFormatter = new Intl.NumberFormat("de-DE", {
 	style: "currency",
 	currency: "EUR",
@@ -122,6 +166,11 @@ const currencyFormatter = new Intl.NumberFormat("de-DE", {
 						{organization.name}'s Dashboard
 					</h1>
 				</section>
+
+				<EventTimeline
+					title="Organization timeline"
+					events={organizationTimeline}
+				/>
 
 				<section
 					aria-labelledby="overview-heading"

--- a/src/pages/dash/org/[slug]/project/[id].astro
+++ b/src/pages/dash/org/[slug]/project/[id].astro
@@ -4,6 +4,7 @@ export const prerender = false;
 // import { Octokit } from "@octokit/rest";
 import { isAPIError } from "better-auth/api";
 import Button from "../../../../../components/Button.astro";
+import EventTimeline from "../../../../../components/EventTimeline.astro";
 import Footer from "../../../../../components/Footer.astro";
 import MilestoneTable from "../../../../../components/MilestoneTable.astro";
 import Nav from "../../../../../components/Nav.astro";
@@ -80,6 +81,32 @@ if (!project) {
 	return Astro.redirect(`/dash/org/${slug}`);
 }
 
+const projectTimeline = await Astro.locals.db.query.event
+	.findMany({
+		columns: {
+			id: true,
+			eventType: true,
+			recordedAt: true,
+			actorType: true,
+		},
+		where: {
+			aggregateType: "project",
+			aggregateId: project.id,
+		},
+		orderBy: {
+			recordedAt: "desc",
+		},
+		limit: 10,
+	})
+	.then((rows) =>
+		rows.map((row) => ({
+			id: row.id,
+			label: row.eventType.replaceAll("_", " "),
+			detail: `Actor: ${row.actorType}`,
+			recordedAt: row.recordedAt,
+		})),
+	);
+
 // let githubIssue = null;
 // let githubIssueError = "";
 
@@ -139,6 +166,8 @@ if (!project) {
 						{project.name}
 					</h1>
 				</section>
+
+				<EventTimeline title="Project timeline" events={projectTimeline} />
 
 				<section>
 					<h2


### PR DESCRIPTION
### Motivation
- Provide a simple, reusable timeline UI to surface recent events related to an organization or project for better visibility. 
- Query and display the last 10 events for organizations (including member actions) and projects so users can quickly see recent activity. 
- Record a pnpm lockfile change to include the patch path for `better-auth@1.6.9` and normalize certain platform metadata.

### Description
- Add `src/components/EventTimeline.astro`, a new component that accepts `title` and `events` props and renders an accessible event list with localized date/time formatting. 
- Integrate the timeline into the organization dashboard at `src/pages/dash/org/[slug].astro`, including database queries to collect organization member IDs and the most recent 10 events (filtered by organization or member actors). 
- Integrate the timeline into the project detail page at `src/pages/dash/org/[slug]/project/[id].astro`, querying the most recent 10 events for the project aggregate. 
- Update imports and schema usage in the org page to include `event`, `member`, and the `or` operator from `drizzle-orm`. 
- Update `pnpm-lock.yaml` to add `path`/`hash` metadata for the patched `better-auth@1.6.9` entry and include lockfile normalization changes for platform/libc entries.

### Testing
- Ran a full build with `pnpm build` which completed successfully. 
- Ran TypeScript checks as part of the build (implicit) and no type errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f655ed9d6083338c1e0e054c88522e)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/craftlions/website/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable EventTimeline and surfaces the last 10 events on organization and project pages, including member actions for orgs. Improves visibility of recent activity with localized date/time.

- **New Features**
  - Added `src/components/EventTimeline.astro` with accessible list UI and localized timestamps.
  - Organization dashboard shows the 10 most recent events from the org and its members.
  - Project page shows the 10 most recent project events.

- **Dependencies**
  - Updated `pnpm-lock.yaml` to add patch `path` and `hash` for `better-auth@1.6.9` and normalize platform/libc metadata.

<sup>Written for commit c3dec48d9401729b11f65dc7ff1e5219a79cc340. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event timelines now display on organization and project pages, showing up to 10 most recent events.
  * Each event includes a label, description, and timestamp for reference.
  * A "no events recorded yet" message appears when the timeline is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->