### PR TITLE
Unify Stripe invoice snapshot persistence

### DIFF
--- a/src/lib/admin-mutations.ts
+++ b/src/lib/admin-mutations.ts
@@ -772,27 +772,6 @@ export const attachInvoiceToPhase = async (
 	});
 };
 
-export const updateStoredStripeStatus = async (
-	db: Db,
-	input: {
-		invoiceId: string;
-		status: string | null;
-		paidAt: Date | null;
-		dueAt: Date | null;
-		fetchedAt: Date;
-	},
-) => {
-	await db
-		.update(invoices)
-		.set({
-			stripeStatus: input.status,
-			stripePaidAt: input.paidAt,
-			stripeDueAt: input.dueAt,
-			fetchedAt: input.fetchedAt,
-		})
-		.where(eq(invoices.id, input.invoiceId));
-};
-
 const writeOrganizationOnboardingRemainder = async (
 	db: Db,
 	actorId: string,

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -63,10 +63,11 @@ const stripeInvoiceSnapshot = (
 	data: StripeInvoiceResponse,
 ): StripeInvoiceSnapshot => ({
 	status: data.status ?? null,
-	paidAt: data.status_transitions?.paid_at
-		? new Date(data.status_transitions.paid_at * 1000)
-		: null,
-	dueAt: data.due_date ? new Date(data.due_date * 1000) : null,
+	paidAt:
+		data.status_transitions?.paid_at != null
+			? new Date(data.status_transitions.paid_at * 1000)
+			: null,
+	dueAt: data.due_date != null ? new Date(data.due_date * 1000) : null,
 	fetchedAt: new Date(),
 });
 
@@ -136,7 +137,7 @@ export const persistStripeInvoiceSnapshot = async (
 		})
 		.onConflictDoUpdate({
 			target: invoices.stripeId,
-			set: { ...invoiceFields, ...stripeFields },
+			set: stripeFields,
 		});
 };
 

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,12 +1,17 @@
 import type { Db } from "./database.ts";
 import { eq } from "drizzle-orm";
-import {
-	assertAdminUser,
-	DomainError,
-	updateStoredStripeStatus,
-} from "./admin-mutations.ts";
+import { assertAdminUser, DomainError } from "./admin-mutations.ts";
 import { invoices } from "./schema.ts";
 import { uuidV7FromDate } from "./uuid.ts";
+
+type StripeTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
+
+export interface StripeInvoiceSnapshot {
+	status: string | null;
+	paidAt: Date | null;
+	dueAt: Date | null;
+	fetchedAt: Date;
+}
 
 interface StripeInvoiceResponse {
 	currency?: string;
@@ -25,6 +30,12 @@ interface StripeInvoiceListItem extends StripeInvoiceResponse {
 	hosted_invoice_url?: string | null;
 	invoice_pdf?: string | null;
 }
+
+type ImportableStripeInvoice = StripeInvoiceListItem & {
+	id: string;
+	number: string;
+	currency: string;
+};
 
 const zeroDecimalCurrencies = new Set([
 	"BIF",
@@ -47,6 +58,83 @@ const zeroDecimalCurrencies = new Set([
 
 const fromStripeMinorUnits = (amount: number, currency: string) =>
 	zeroDecimalCurrencies.has(currency.toUpperCase()) ? amount : amount / 100;
+
+const stripeInvoiceSnapshot = (
+	data: StripeInvoiceResponse,
+): StripeInvoiceSnapshot => ({
+	status: data.status ?? null,
+	paidAt: data.status_transitions?.paid_at
+		? new Date(data.status_transitions.paid_at * 1000)
+		: null,
+	dueAt: data.due_date ? new Date(data.due_date * 1000) : null,
+	fetchedAt: new Date(),
+});
+
+const isImportableStripeInvoice = (
+	item: StripeInvoiceListItem,
+): item is ImportableStripeInvoice =>
+	Boolean(
+		item.id &&
+			item.number &&
+			item.currency &&
+			item.status !== "draft" &&
+			(item.hosted_invoice_url || item.invoice_pdf),
+	);
+
+export const persistStripeInvoiceSnapshot = async (
+	tx: StripeTransaction,
+	input:
+		| {
+				invoiceId: string;
+				snapshot: StripeInvoiceSnapshot;
+		  }
+		| {
+				organizationId: string;
+				stripeInvoice: ImportableStripeInvoice;
+				snapshot: StripeInvoiceSnapshot;
+		  },
+) => {
+	const stripeFields = {
+		stripeStatus: input.snapshot.status,
+		stripePaidAt: input.snapshot.paidAt,
+		stripeDueAt: input.snapshot.dueAt,
+		fetchedAt: input.snapshot.fetchedAt,
+	};
+
+	if ("invoiceId" in input) {
+		await tx
+			.update(invoices)
+			.set(stripeFields)
+			.where(eq(invoices.id, input.invoiceId));
+		return;
+	}
+
+	await tx
+		.insert(invoices)
+		.values({
+			id: input.stripeInvoice.created
+				? uuidV7FromDate(new Date(input.stripeInvoice.created * 1000))
+				: undefined,
+			publicId: crypto.randomUUID(),
+			organizationId: input.organizationId,
+			invoiceNumber: input.stripeInvoice.number,
+			stripeId: input.stripeInvoice.id,
+			stripePaymentPage:
+				input.stripeInvoice.hosted_invoice_url ??
+				input.stripeInvoice.invoice_pdf ??
+				"",
+			currency: input.stripeInvoice.currency.toUpperCase(),
+			total: fromStripeMinorUnits(
+				input.stripeInvoice.total ?? 0,
+				input.stripeInvoice.currency,
+			),
+			...stripeFields,
+		})
+		.onConflictDoUpdate({
+			target: invoices.stripeId,
+			set: stripeFields,
+		});
+};
 
 export const refreshStripeInvoice = async (
 	db: Db,
@@ -110,15 +198,12 @@ export const refreshStripeInvoice = async (
 		);
 	}
 
-	await updateStoredStripeStatus(db, {
-		invoiceId: invoice.id,
-		status: data.status ?? null,
-		paidAt: data.status_transitions?.paid_at
-			? new Date(data.status_transitions.paid_at * 1000)
-			: null,
-		dueAt: data.due_date ? new Date(data.due_date * 1000) : null,
-		fetchedAt: new Date(),
-	});
+	await db.transaction((tx) =>
+		persistStripeInvoiceSnapshot(tx, {
+			invoiceId: invoice.id,
+			snapshot: stripeInvoiceSnapshot(data),
+		}),
+	);
 };
 
 export const importStripeInvoices = async (
@@ -169,44 +254,17 @@ export const importStripeInvoices = async (
 	} while (startingAfter);
 
 	for (const item of fetched) {
-		if (
-			!item.id ||
-			!item.number ||
-			!item.currency ||
-			item.status === "draft" ||
-			(!item.hosted_invoice_url && !item.invoice_pdf)
-		) {
+		if (!isImportableStripeInvoice(item)) {
 			continue;
 		}
 
-		const stripeFields = {
-			stripeStatus: item.status ?? null,
-			stripePaidAt: item.status_transitions?.paid_at
-				? new Date(item.status_transitions.paid_at * 1000)
-				: null,
-			stripeDueAt: item.due_date ? new Date(item.due_date * 1000) : null,
-			fetchedAt: new Date(),
-		};
-
-		await db
-			.insert(invoices)
-			.values({
-				id: item.created
-					? uuidV7FromDate(new Date(item.created * 1000))
-					: undefined,
-				publicId: crypto.randomUUID(),
+		await db.transaction((tx) =>
+			persistStripeInvoiceSnapshot(tx, {
 				organizationId: input.organizationId,
-				invoiceNumber: item.number,
-				stripeId: item.id,
-				stripePaymentPage: item.hosted_invoice_url ?? item.invoice_pdf ?? "",
-				currency: item.currency.toUpperCase(),
-				total: fromStripeMinorUnits(item.total ?? 0, item.currency),
-				...stripeFields,
-			})
-			.onConflictDoUpdate({
-				target: invoices.stripeId,
-				set: stripeFields,
-			});
+				stripeInvoice: item,
+				snapshot: stripeInvoiceSnapshot(item),
+			}),
+		);
 	}
 };
 

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -109,6 +109,19 @@ export const persistStripeInvoiceSnapshot = async (
 		return;
 	}
 
+	const invoiceFields = {
+		invoiceNumber: input.stripeInvoice.number,
+		stripePaymentPage:
+			input.stripeInvoice.hosted_invoice_url ??
+			input.stripeInvoice.invoice_pdf ??
+			"",
+		currency: input.stripeInvoice.currency.toUpperCase(),
+		total: fromStripeMinorUnits(
+			input.stripeInvoice.total ?? 0,
+			input.stripeInvoice.currency,
+		),
+	};
+
 	await tx
 		.insert(invoices)
 		.values({
@@ -117,22 +130,13 @@ export const persistStripeInvoiceSnapshot = async (
 				: undefined,
 			publicId: crypto.randomUUID(),
 			organizationId: input.organizationId,
-			invoiceNumber: input.stripeInvoice.number,
 			stripeId: input.stripeInvoice.id,
-			stripePaymentPage:
-				input.stripeInvoice.hosted_invoice_url ??
-				input.stripeInvoice.invoice_pdf ??
-				"",
-			currency: input.stripeInvoice.currency.toUpperCase(),
-			total: fromStripeMinorUnits(
-				input.stripeInvoice.total ?? 0,
-				input.stripeInvoice.currency,
-			),
+			...invoiceFields,
 			...stripeFields,
 		})
 		.onConflictDoUpdate({
 			target: invoices.stripeId,
-			set: stripeFields,
+			set: { ...invoiceFields, ...stripeFields },
 		});
 };
 


### PR DESCRIPTION
## Summary

- Add one transaction-scoped Stripe invoice snapshot persistence contract for existing-invoice refreshes and organization-wide imports.
- Normalize status, paid time, due time, and fetch time through the same snapshot mapping.
- Preserve refresh validation and bulk-import filtering/upsert behavior.

This keeps equivalent Stripe input stored identically across both fetch paths and leaves notification delivery out of scope.

## Validation

- `aubx drizzle-kit check`
- `aubr types`
- `aubr cf-check`
- `aubx astro sync`
- `aubx biome check --write`
- `aube exec tsc --noEmit`
- `aubr check` reaches Astro diagnostics but is blocked by the cached Astro language-server `fileExists` exception before project diagnostics.

Closes #250

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies Stripe invoice snapshot persistence across invoice refresh and org-wide import, writing the same status/paid/due/fetched fields atomically while preserving snapshot boundaries. On conflict, only snapshot fields are updated; core invoice fields remain unchanged. Closes #250.

- **Refactors**
  - Added `stripeInvoiceSnapshot` and transaction-scoped `persistStripeInvoiceSnapshot` to map and persist snapshots in one place.
  - Replaced direct updates with `db.transaction(...)` and removed `updateStoredStripeStatus`. On conflict by `invoices.stripeId`, update only snapshot fields; inserts set number, payment page, currency, total.
  - Preserved import filtering with `isImportableStripeInvoice`.

<sup>Written for commit 005b25d97e7b28d4522d26c459f72aeb107737bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/craftlions/website/pull/258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stripe invoice imports and refreshes with consistent snapshot handling.
  * Added validation to skip invoices that cannot be imported.
  * Ensured invoice updates are saved reliably through transactional upserts.
  * Preserved invoice status, payment date, due date, and fetch timestamp during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->