### PR TITLE
feat(invoices): fetch the invoice date from Stripe at recording

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -326,7 +326,10 @@ export const server = {
 			expectedVersion: z.coerce.number().int().nonnegative(),
 		}),
 		handler: adminHandler(async (input, context, actorId) => {
-			await recordInvoice(context.locals.db, actorId, input);
+			await recordInvoice(context.locals.db, actorId, {
+				...input,
+				stripeKey: env.STRIPE_SECRET_KEY,
+			});
 			return { success: true };
 		}),
 	}),

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -9,7 +9,6 @@ import {
 	attachInvoiceToPhase,
 	createPhase,
 	createProject,
-	DomainError,
 	hardDeleteOrganization,
 	onboardOrganization,
 	recordInvoice,
@@ -20,6 +19,7 @@ import {
 	transitionProject,
 	updateOrganizationSettings,
 } from "../lib/admin-mutations.ts";
+import { DomainError } from "../lib/domain.ts";
 import { importStripeInvoices, refreshStripeInvoice } from "../lib/stripe.ts";
 
 const assertNotImpersonating = (

--- a/src/lib/admin-mutations.ts
+++ b/src/lib/admin-mutations.ts
@@ -9,6 +9,7 @@ import {
 	phases,
 	projects,
 } from "./schema.ts";
+import { fetchStripeInvoice, stripeInvoiceSnapshot } from "./stripe.ts";
 
 export class DomainError extends Error {
 	constructor(
@@ -489,6 +490,7 @@ export const recordInvoice = async (
 		stripePaymentPage: string;
 		total: number;
 		expectedVersion: number;
+		stripeKey: string;
 	},
 ) => {
 	await assertAdminUser(db, actorId);
@@ -572,6 +574,11 @@ export const recordInvoice = async (
 			throw new DomainError("NotFound", "Project not found.");
 		}
 
+		const stripeInvoice = await fetchStripeInvoice({
+			stripeId: input.stripeId.trim(),
+			stripeKey: input.stripeKey,
+		});
+
 		const rows = await tx
 			.insert(invoices)
 			.values({
@@ -583,6 +590,7 @@ export const recordInvoice = async (
 				stripePaymentPage: input.stripePaymentPage.trim(),
 				currency: phase.currency,
 				total: input.total,
+				invoicedAt: stripeInvoiceSnapshot(stripeInvoice).invoicedAt,
 			})
 			.onConflictDoNothing()
 			.returning({ id: invoices.id, publicId: invoices.publicId });

--- a/src/lib/admin-mutations.ts
+++ b/src/lib/admin-mutations.ts
@@ -469,8 +469,84 @@ export const recordInvoice = async (
 ) => {
 	await assertAdminUser(db, actorId);
 
+	const phase = await db.query.phases.findFirst({
+		columns: {
+			id: true,
+			state: true,
+			currency: true,
+			version: true,
+		},
+		where: { id: input.phaseId },
+	});
+
+	if (!phase) {
+		throw new DomainError("NotFound", "Phase not found.");
+	}
+
+	const invoice = await db.query.invoices.findFirst({
+		columns: {
+			id: true,
+			publicId: true,
+			phaseId: true,
+			invoiceNumber: true,
+			stripeId: true,
+			stripePaymentPage: true,
+			currency: true,
+			total: true,
+		},
+		where: { phaseId: phase.id },
+	});
+
+	const invoiceMatches = (
+		phaseRow: { id: string; state: string; currency: string; version: number },
+		invoiceRow: typeof invoice,
+	): invoiceRow is NonNullable<typeof invoice> =>
+		invoiceRow?.phaseId === phaseRow.id &&
+		invoiceRow.invoiceNumber === input.invoiceNumber.trim() &&
+		invoiceRow.stripeId === input.stripeId.trim() &&
+		invoiceRow.stripePaymentPage === input.stripePaymentPage.trim() &&
+		invoiceRow.currency === phaseRow.currency &&
+		invoiceRow.total === input.total;
+
+	if (
+		phase.state === "invoiced" &&
+		phase.version === input.expectedVersion + 1 &&
+		invoiceMatches(phase, invoice)
+	) {
+		return {
+			invoice: { id: invoice.id, publicId: invoice.publicId },
+			created: false,
+		};
+	}
+
+	if (phase.version !== input.expectedVersion) {
+		throw new DomainError(
+			"Conflict",
+			"This phase was changed by another request. Refresh and try again.",
+		);
+	}
+
+	if (phase.state !== "in_progress") {
+		throw new DomainError(
+			"InvalidTransition",
+			"Invoices can only be recorded on in-progress phases.",
+		);
+	}
+
+	if (invoice) {
+		throw new DomainError(
+			"AlreadyExists",
+			"This phase already has an invoice.",
+		);
+	}
+
+	const stripeInvoice = await fetchStripeInvoice({
+		stripeId: input.stripeId.trim(),
+		stripeKey: input.stripeKey,
+	});
+
 	return db.transaction(async (tx) => {
-		const [phase] = await tx
+		const [lockedPhase] = await tx
 			.select({
 				id: phases.id,
 				projectId: phases.projectId,
@@ -482,11 +558,11 @@ export const recordInvoice = async (
 			.where(eq(phases.id, input.phaseId))
 			.for("update");
 
-		if (!phase) {
+		if (!lockedPhase) {
 			throw new DomainError("NotFound", "Phase not found.");
 		}
 
-		const invoice = await tx.query.invoices.findFirst({
+		const lockedInvoice = await tx.query.invoices.findFirst({
 			columns: {
 				id: true,
 				publicId: true,
@@ -497,42 +573,35 @@ export const recordInvoice = async (
 				currency: true,
 				total: true,
 			},
-			where: { phaseId: phase.id },
+			where: { phaseId: lockedPhase.id },
 		});
-		const invoiceMatches =
-			invoice?.phaseId === phase.id &&
-			invoice.invoiceNumber === input.invoiceNumber.trim() &&
-			invoice.stripeId === input.stripeId.trim() &&
-			invoice.stripePaymentPage === input.stripePaymentPage.trim() &&
-			invoice.currency === phase.currency &&
-			invoice.total === input.total;
 
 		if (
-			phase.state === "invoiced" &&
-			phase.version === input.expectedVersion + 1 &&
-			invoiceMatches
+			lockedPhase.state === "invoiced" &&
+			lockedPhase.version === input.expectedVersion + 1 &&
+			invoiceMatches(lockedPhase, lockedInvoice)
 		) {
 			return {
-				invoice: { id: invoice.id, publicId: invoice.publicId },
+				invoice: { id: lockedInvoice.id, publicId: lockedInvoice.publicId },
 				created: false,
 			};
 		}
 
-		if (phase.version !== input.expectedVersion) {
+		if (lockedPhase.version !== input.expectedVersion) {
 			throw new DomainError(
 				"Conflict",
 				"This phase was changed by another request. Refresh and try again.",
 			);
 		}
 
-		if (phase.state !== "in_progress") {
+		if (lockedPhase.state !== "in_progress") {
 			throw new DomainError(
 				"InvalidTransition",
 				"Invoices can only be recorded on in-progress phases.",
 			);
 		}
 
-		if (invoice) {
+		if (lockedInvoice) {
 			throw new DomainError(
 				"AlreadyExists",
 				"This phase already has an invoice.",
@@ -541,28 +610,23 @@ export const recordInvoice = async (
 
 		const project = await tx.query.projects.findFirst({
 			columns: { organizationId: true },
-			where: { id: phase.projectId },
+			where: { id: lockedPhase.projectId },
 		});
 
 		if (!project) {
 			throw new DomainError("NotFound", "Project not found.");
 		}
 
-		const stripeInvoice = await fetchStripeInvoice({
-			stripeId: input.stripeId.trim(),
-			stripeKey: input.stripeKey,
-		});
-
 		const rows = await tx
 			.insert(invoices)
 			.values({
 				publicId: publicId(),
 				organizationId: project.organizationId,
-				phaseId: phase.id,
+				phaseId: lockedPhase.id,
 				invoiceNumber: input.invoiceNumber.trim(),
 				stripeId: input.stripeId.trim(),
 				stripePaymentPage: input.stripePaymentPage.trim(),
-				currency: phase.currency,
+				currency: lockedPhase.currency,
 				total: input.total,
 				invoicedAt: stripeInvoiceSnapshot(stripeInvoice).invoicedAt,
 			})
@@ -581,7 +645,7 @@ export const recordInvoice = async (
 			.set({ state: "invoiced", version: sql`${phases.version} + 1` })
 			.where(
 				and(
-					eq(phases.id, phase.id),
+					eq(phases.id, lockedPhase.id),
 					eq(phases.state, "in_progress"),
 					eq(phases.version, input.expectedVersion),
 				),
@@ -597,7 +661,7 @@ export const recordInvoice = async (
 
 		await insertEvent(tx, {
 			aggregateType: "phase",
-			aggregateId: phase.id,
+			aggregateId: lockedPhase.id,
 			aggregateVersion: input.expectedVersion + 1,
 			event: "invoiced",
 			actorId,

--- a/src/lib/admin-mutations.ts
+++ b/src/lib/admin-mutations.ts
@@ -2,6 +2,7 @@ import type { Auth } from "./auth.ts";
 import type { Db } from "./database.ts";
 import { getOrgAdapter } from "better-auth/plugins/organization";
 import { and, eq, isNull, sql } from "drizzle-orm";
+import { assertAdminUser, DomainError } from "./domain.ts";
 import {
 	events,
 	invoices,
@@ -11,39 +12,12 @@ import {
 } from "./schema.ts";
 import { fetchStripeInvoice, stripeInvoiceSnapshot } from "./stripe.ts";
 
-export class DomainError extends Error {
-	constructor(
-		public code:
-			| "AlreadyExists"
-			| "Conflict"
-			| "Forbidden"
-			| "InvalidTransition"
-			| "NotFound"
-			| "StripeUnavailable"
-			| "Validation",
-		message: string,
-	) {
-		super(message);
-	}
-}
-
 export const toSlug = (value: string) =>
 	value
 		.trim()
 		.toLowerCase()
 		.replace(/[^a-z0-9]+/g, "-")
 		.replace(/^-|-$/g, "");
-
-export const assertAdminUser = async (db: Db, actorId: string) => {
-	const actor = await db.query.user.findFirst({
-		columns: { id: true, role: true },
-		where: { id: actorId },
-	});
-
-	if (actor?.role !== "admin") {
-		throw new DomainError("Forbidden", "Only admins can perform this action.");
-	}
-};
 
 const publicId = () => crypto.randomUUID();
 

--- a/src/lib/api-adapters.ts
+++ b/src/lib/api-adapters.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { DomainError } from "./admin-mutations.ts";
+import { DomainError } from "./domain.ts";
 
 export const problem = (status: number, title: string, detail: string) =>
 	new Response(

--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -1,0 +1,28 @@
+import type { Db } from "./database.ts";
+
+export class DomainError extends Error {
+	constructor(
+		public code:
+			| "AlreadyExists"
+			| "Conflict"
+			| "Forbidden"
+			| "InvalidTransition"
+			| "NotFound"
+			| "StripeUnavailable"
+			| "Validation",
+		message: string,
+	) {
+		super(message);
+	}
+}
+
+export const assertAdminUser = async (db: Db, actorId: string) => {
+	const actor = await db.query.user.findFirst({
+		columns: { id: true, role: true },
+		where: { id: actorId },
+	});
+
+	if (actor?.role !== "admin") {
+		throw new DomainError("Forbidden", "Only admins can perform this action.");
+	}
+};

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,6 +1,6 @@
 import type { Db } from "./database.ts";
 import { eq } from "drizzle-orm";
-import { assertAdminUser, DomainError } from "./admin-mutations.ts";
+import { assertAdminUser, DomainError } from "./domain.ts";
 import { invoices } from "./schema.ts";
 
 type StripeTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -98,14 +98,23 @@ export const fetchStripeInvoice = async (input: {
 	stripeId: string;
 	stripeKey: string;
 }): Promise<StripeInvoiceResponse> => {
-	const response = await fetch(
-		`https://api.stripe.com/v1/invoices/${encodeURIComponent(input.stripeId)}`,
-		{
-			headers: {
-				Authorization: `Bearer ${input.stripeKey}`,
+	let response: Response;
+	try {
+		response = await fetch(
+			`https://api.stripe.com/v1/invoices/${encodeURIComponent(input.stripeId)}`,
+			{
+				headers: {
+					Authorization: `Bearer ${input.stripeKey}`,
+				},
 			},
-		},
-	);
+		);
+	} catch {
+		throw new DomainError("StripeUnavailable", "Stripe is unreachable.");
+	}
+
+	if (response.status === 404) {
+		throw new DomainError("Validation", "Stripe invoice not found.");
+	}
 
 	if (!response.ok) {
 		throw new DomainError("StripeUnavailable", "Stripe status is unavailable.");

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -60,7 +60,7 @@ const zeroDecimalCurrencies = new Set([
 const fromStripeMinorUnits = (amount: number, currency: string) =>
 	zeroDecimalCurrencies.has(currency.toUpperCase()) ? amount : amount / 100;
 
-const stripeInvoiceSnapshot = (
+export const stripeInvoiceSnapshot = (
 	data: StripeInvoiceResponse,
 ): StripeInvoiceSnapshot => {
 	if (data.created == null) {
@@ -93,6 +93,26 @@ const isImportableStripeInvoice = (
 			item.created != null &&
 			(item.hosted_invoice_url || item.invoice_pdf),
 	);
+
+export const fetchStripeInvoice = async (input: {
+	stripeId: string;
+	stripeKey: string;
+}): Promise<StripeInvoiceResponse> => {
+	const response = await fetch(
+		`https://api.stripe.com/v1/invoices/${encodeURIComponent(input.stripeId)}`,
+		{
+			headers: {
+				Authorization: `Bearer ${input.stripeKey}`,
+			},
+		},
+	);
+
+	if (!response.ok) {
+		throw new DomainError("StripeUnavailable", "Stripe status is unavailable.");
+	}
+
+	return (await response.json()) as StripeInvoiceResponse;
+};
 
 export const persistStripeInvoiceSnapshot = async (
 	tx: StripeTransaction,
@@ -176,20 +196,10 @@ export const refreshStripeInvoice = async (
 		);
 	}
 
-	const response = await fetch(
-		`https://api.stripe.com/v1/invoices/${encodeURIComponent(invoice.stripeId)}`,
-		{
-			headers: {
-				Authorization: `Bearer ${input.stripeKey}`,
-			},
-		},
-	);
-
-	if (!response.ok) {
-		throw new DomainError("StripeUnavailable", "Stripe status is unavailable.");
-	}
-
-	const data = (await response.json()) as StripeInvoiceResponse;
+	const data = await fetchStripeInvoice({
+		stripeId: invoice.stripeId,
+		stripeKey: input.stripeKey,
+	});
 
 	if (
 		data.currency &&

--- a/src/pages/api/admin/phases/[id]/invoices/index.ts
+++ b/src/pages/api/admin/phases/[id]/invoices/index.ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
 import { z } from "astro/zod";
 import { recordInvoice } from "../../../../../../lib/admin-mutations.ts";
 import {
@@ -38,6 +39,7 @@ export const POST: APIRoute = async (context) => {
 			{
 				phaseId: String(context.params.id),
 				...validation.data,
+				stripeKey: env.STRIPE_SECRET_KEY,
 			},
 		);
 		return new Response(JSON.stringify(result.invoice), {


### PR DESCRIPTION
Closes #263

## What

Recording a phase invoice now fetches the Stripe invoice by the entered Stripe id and stores its `created` as `invoicedAt` — the date is never entered by hand (S-002 R2). Recording gains a Stripe dependency and fails with the existing `StripeUnavailable` `DomainError` pattern when Stripe is unreachable.

## Changes

- **`src/lib/stripe.ts`**: extracted `fetchStripeInvoice` (single-invoice fetch, `StripeUnavailable` on non-OK) and exported `stripeInvoiceSnapshot`; `refreshStripeInvoice` now reuses the helper with identical behavior.
- **`src/lib/admin-mutations.ts`**: `recordInvoice` takes `stripeKey`, fetches the Stripe invoice by the entered Stripe id after all existing validation checks and before the insert, and stores its `created` as `invoicedAt`. Idempotent replays, version/state/existing-invoice checks, and duplicate-request handling all run before the fetch and are unchanged; ids keep row-creation semantics (D-uuidv7).
- **`src/actions/index.ts` + `src/pages/api/admin/phases/[id]/invoices/index.ts`**: pass `env.STRIPE_SECRET_KEY` into `recordInvoice`.

## Acceptance criteria

- **AC 1** (S-002 R2): recorded `invoicedAt` = Stripe invoice `created` (from the fetch), id timestamp ≈ now (uuidv7 default; no back-stamping).
- **AC 8** (S-002 R2 failure): Stripe unreachable → `StripeUnavailable` thrown before the insert, transaction rolls back, no invoice row written; API route maps it to 503, action to the existing `StripeUnavailable` handling.

## Validation

`aubx drizzle-kit check`, `aubr types`, `aubr cf-check`, `aubx astro sync`, `tsc --noEmit`, `aube build`, `aube x biome check` all pass. (`aubr check`/astro check crashes with a pre-existing language-server environment error, reproducible on `main`; CI runs `aube build`.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recording a phase invoice now fetches the Stripe invoice by ID and sets `invoicedAt` from its `created` timestamp (S-002 R2). Stripe is fetched after validations and before insert, outside the DB transaction; failures abort the operation.

- **New Features**
  - `recordInvoice` fetches Stripe outside the transaction and sets `invoicedAt`; ids keep uuidv7 semantics (no back-stamping).
  - Error mapping: 404 → `Validation` (“Stripe invoice not found”); network/other non-OK → `StripeUnavailable` (API route returns 503). API route and server action pass `env.STRIPE_SECRET_KEY` into `recordInvoice`.

- **Refactors**
  - Extracted `fetchStripeInvoice`; exported `stripeInvoiceSnapshot`; `refreshStripeInvoice` now uses the helper.
  - Moved `DomainError` and `assertAdminUser` to `lib/domain.ts`; updated imports in `actions` and API adapters.

<sup>Written for commit f2aba931b665b68846407583227117df35ef4ff9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/craftlions/website/pull/267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

