### PR TITLE
Expose exact phase evidence targets (Epic + Delivery)

### DIFF
--- a/src/components/PhasesTable.astro
+++ b/src/components/PhasesTable.astro
@@ -77,7 +77,7 @@ const phaseStateToBadgeType = (phaseState: phaseSelectType["state"]) => {
 					</thead>
 					<tbody>
 						{phases.map((phase) => (
-							<tr id={`phase-${phase.publicId}`} class="border-b border-dashed border-neutral-300 transition-colors last:border-b-0 hover:bg-neutral-100/70 dark:border-neutral-700 dark:hover:bg-neutral-900/70">
+							<tr id={`phase-${phase.publicId}`} class="border-b border-dashed border-neutral-300 last:border-b-0 hover:bg-neutral-100/70 dark:border-neutral-700 dark:hover:bg-neutral-900/70">
 								<td class="px-4 py-4 font-medium text-neutral-900 dark:text-neutral-100">
 									{phase.title}
 								</td>
@@ -163,26 +163,48 @@ const phaseStateToBadgeType = (phaseState: phaseSelectType["state"]) => {
 
 <script>
 	// Exact phase evidence target: a client phase link points at the stable
-	// `phase-<publicId>` fragment on this project page. On landing, bring the exact
-	// row into view and mark it targeted with both a background tint and a
-	// non-color outline cue, persisting in light and dark mode without motion.
-	const phaseFragment = location.hash.slice(1);
+	// `phase-<publicId>` fragment on this project page. Bring the exact row into
+	// view and mark it targeted with a background tint plus a non-color outline
+	// cue, persisting in light and dark mode without motion. The tint survives
+	// hover because the neutral hover fill is swapped off the targeted row. Runs
+	// on landing and on every fragment change, clearing the previous target.
+	const highlightClasses = [
+		"outline-2",
+		"outline-dashed",
+		"outline-sky-500/70",
+		"bg-sky-100/60",
+		"hover:bg-sky-100/60",
+		"dark:outline-sky-400/70",
+		"dark:bg-sky-950/50",
+		"dark:hover:bg-sky-950/50",
+	];
+	const neutralHoverClasses = [
+		"hover:bg-neutral-100/70",
+		"dark:hover:bg-neutral-900/70",
+	];
+	let currentTarget: HTMLTableRowElement | null = null;
 
-	if (phaseFragment) {
-		const target = document.getElementById(phaseFragment);
-
-		if (target instanceof HTMLTableRowElement) {
-			target.scrollIntoView({ block: "center" });
-			target.classList.add(
-				"outline-2",
-				"outline-dashed",
-				"outline-sky-500/70",
-				"bg-sky-100/60",
-				"dark:outline-sky-400/70",
-				"dark:bg-sky-950/50",
-			);
+	const applyPhaseTarget = () => {
+		if (currentTarget instanceof HTMLTableRowElement) {
+			currentTarget.classList.remove(...highlightClasses);
+			currentTarget.classList.add(...neutralHoverClasses);
+			currentTarget = null;
 		}
-	}
+
+		const phaseFragment = location.hash.slice(1);
+		if (!phaseFragment) return;
+
+		const target = document.getElementById(phaseFragment);
+		if (target instanceof HTMLTableRowElement) {
+			target.classList.remove(...neutralHoverClasses);
+			target.classList.add(...highlightClasses);
+			target.scrollIntoView({ block: "center" });
+			currentTarget = target;
+		}
+	};
+
+	applyPhaseTarget();
+	window.addEventListener("hashchange", applyPhaseTarget);
 </script>
 
 <script>

--- a/src/components/PhasesTable.astro
+++ b/src/components/PhasesTable.astro
@@ -13,6 +13,8 @@ interface Phase {
 	state: phaseSelectType["state"];
 	version: phaseSelectType["version"];
 	externalUrl: phaseSelectType["externalUrl"];
+	deliveryState: phaseSelectType["deliveryState"];
+	deliveryUrl: phaseSelectType["deliveryUrl"];
 }
 
 interface Props {
@@ -63,7 +65,10 @@ const phaseStateToBadgeType = (phaseState: phaseSelectType["state"]) => {
 								State
 							</th>
 							<th scope="col" class="px-4 py-3 text-xs font-semibold uppercase">
-								Link
+								Epic
+							</th>
+							<th scope="col" class="px-4 py-3 text-xs font-semibold uppercase">
+								Delivery
 							</th>
 							<th scope="col" class="px-4 py-3 text-xs font-semibold uppercase">
 								Actions
@@ -72,7 +77,7 @@ const phaseStateToBadgeType = (phaseState: phaseSelectType["state"]) => {
 					</thead>
 					<tbody>
 						{phases.map((phase) => (
-							<tr class="border-b border-dashed border-neutral-300 transition-colors last:border-b-0 hover:bg-neutral-100/70 dark:border-neutral-700 dark:hover:bg-neutral-900/70">
+							<tr id={`phase-${phase.publicId}`} class="border-b border-dashed border-neutral-300 transition-colors last:border-b-0 hover:bg-neutral-100/70 dark:border-neutral-700 dark:hover:bg-neutral-900/70">
 								<td class="px-4 py-4 font-medium text-neutral-900 dark:text-neutral-100">
 									{phase.title}
 								</td>
@@ -98,9 +103,26 @@ const phaseStateToBadgeType = (phaseState: phaseSelectType["state"]) => {
 										href={phase.externalUrl}
 										target="_blank"
 										rel="noopener noreferrer"
+										aria-label={`Open Epic for ${phase.title}`}
+									>
+										Epic
+									</Button>
+								)}
+							</td>
+							<td class="px-4 py-4">
+								{phase.deliveryState === "url" && phase.deliveryUrl ? (
+									<Button
+										href={phase.deliveryUrl}
+										target="_blank"
+										rel="noopener noreferrer"
+										aria-label={`Open Delivery for ${phase.title}`}
 									>
 										Open
 									</Button>
+								) : phase.deliveryState === "none" ? (
+									<span class="text-neutral-600 dark:text-neutral-400">No delivery</span>
+								) : (
+									<span class="text-neutral-500 dark:text-neutral-400">Not recorded</span>
 								)}
 							</td>
 							<td class="px-4 py-4">
@@ -138,6 +160,30 @@ const phaseStateToBadgeType = (phaseState: phaseSelectType["state"]) => {
 			</p>
 	)}
 </div>
+
+<script>
+	// Exact phase evidence target: a client phase link points at the stable
+	// `phase-<publicId>` fragment on this project page. On landing, bring the exact
+	// row into view and mark it targeted with both a background tint and a
+	// non-color outline cue, persisting in light and dark mode without motion.
+	const phaseFragment = location.hash.slice(1);
+
+	if (phaseFragment) {
+		const target = document.getElementById(phaseFragment);
+
+		if (target instanceof HTMLTableRowElement) {
+			target.scrollIntoView({ block: "center" });
+			target.classList.add(
+				"outline-2",
+				"outline-dashed",
+				"outline-sky-500/70",
+				"bg-sky-100/60",
+				"dark:outline-sky-400/70",
+				"dark:bg-sky-950/50",
+			);
+		}
+	}
+</script>
 
 <script>
 	document.addEventListener("submit", (event) => {

--- a/src/pages/dash/org/[slug]/project/[publicId].astro
+++ b/src/pages/dash/org/[slug]/project/[publicId].astro
@@ -77,6 +77,8 @@ const project = await Astro.locals.db.query.projects.findFirst({
 				state: true,
 				version: true,
 				externalUrl: true,
+				deliveryState: true,
+				deliveryUrl: true,
 			},
 			with: {},
 			orderBy: {


### PR DESCRIPTION
## Why
Supports O-003 — traceable invoice context. Each client phase row becomes an exact, visibly targeted destination exposing the existing client-tracker Epic and the phase-owned Delivery evidence separately, so reviewers reach the right evidence without matching wording.

## Implements
Closes #270

## Decisions followed
- **S-003 — Linked invoice work context** (frozen by epic 268), AC4, AC5, AC9, R1/R4/R5/R10
- **O-003 — traceable invoice context**

## Decisions made
(BuildContext: this issue owns the project-page *destination*; the invoice-table Work/Delivery *source* links are sibling #272, which is blocked by this issue.)
- **Stable fragment contract `#phase-{publicId}`** over an index-based or section-only anchor, because the phase public ID is stable and unique and gives sibling #272 a deterministic row target. Reversible.
- **Highlight = persistent background tint + 2px dashed outline** (non-color geometric cue) over a color-only or animated/pulsing highlight, to satisfy "without motion or color-only meaning" in both light and dark. Reversible.
- **`No delivery` and `Not recorded` rendered as plain text** (not links) because those states have no URL to open, keeping only the `Open` delivery as a link. Reversible.
- **Epic link relabeled `Open` → `Epic`** with a descriptive `aria-label` for accessible naming. Reversible.

## Verification
These are browser tests (AC4/AC5/AC9). Full end-to-end authenticated runs against the live app could not be performed here: the app requires an account (email+verification / GitHub OAuth) and no credentials are available, and the shared PlanetScale database (read-only per Safety) forbids seeding test phases. The sandbox node also cannot resolve the DB host while the browser/network reach other hosts.

In lieu of that, I proved the behavior empirically in a scratch Playwright harness that renders the **actual** PhasesTable markup for fixture phases and runs the **verbatim** targeting script, styled by the **actual built Tailwind CSS** (the new classes confirmed present in `dist/client/_astro/Shell.*.css`).

- **AC4 — stable fragment target, in-view landing, persistent light/dark targeted state.** Loading `/project/{id}#phase-B` placed row B in view (`getBoundingClientRect` within viewport) and applied the target classes after first paint. Computed style in light: sky background tint (`bg-sky-100/60`) + `dashed` 2px `outline-sky-500/70`; `animation: none` and `transition-duration: 0s` (no motion, applies instantly). Emulating `prefers-color-scheme: dark` kept the visible tint (`dark:bg-sky-950/50`) and `dark:outline-sky-400/70` outline — a non-color cue persists in both modes.
- **Review fixes (AC4 robustness).** Verified empirically after the review round: the highlight no longer fades (no `transition-colors` on the row); a same-document fragment change (`location.hash` `#phase-A` → `#phase-B`) retargets the new row and clears the prior one (no ghost highlight, hover restored on the old row); hovering a targeted row keeps the sky tint in both light and dark (neutral hover fill is swapped for the sky hover, restored on clear). An empty fragment clears the highlight.
- **AC5 — distinct, keyboard-reachable Epic and Delivery destinations.** Row with both show two anchors: `Epic → https://github.com/craftlions/website/compare/…` and `Open (Delivery) → …/pull/…`, each with `target="_blank"`, `rel="noopener noreferrer"`, and descriptive `aria-label` (`Open Epic for …`, `Open Delivery for …`). Tabbing focused an Epic anchor (real `<a>`, keyboard-reachable). `No delivery` and `Not recorded` rows render the correct text and only link the `Open` state.
- **AC9 — descriptive accessible names and safe new-context behavior.** Confirmed above: external Epic and Delivery links carry accessible destination labels and `target="_blank" rel="noopener noreferrer"`; non-link state text is not clickable. (Internal Work-link navigation is sibling #272's side, out of scope per the issue.)

**Static/structural validation (clean):** `aubx drizzle-kit check`, `aubr types`, `aubr cf-check`, `aubx astro sync` (0 errors), `aubr check` (0 errors/0 warnings/0 hints), `aubx biome check --write` (no fixes), and a production `astro build` that compiled and emitted the new Tailwind utilities.

## Risks and manual steps
- None for this change itself (no schema change, no migration, no config).
- **Contract dependency for #272:** the invoice Work column's phase links should target the exact URL `/dash/org/{slug}/project/{projectPublicId}#phase-{phasePublicId}` — that fragment is what this issue establishes as the highlighted destination.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose exact evidence targets for each project phase by linking rows via `#phase-{publicId}` and separating Epic and Delivery; the highlight is motion-free, hover-safe, and re-targets on hash changes. Closes #270; aligns with O-003 and S-003 (AC4/AC5/AC9).

- **New Features**
  - Each phase row has a stable fragment ID and scrolls into view with a persistent, accessible target highlight (dashed outline + tint, light/dark).
  - The old “Link” column is split into “Epic” and “Delivery”: Epic opens the client-tracker URL; Delivery shows Open, No delivery, or Not recorded with clear labels and safe new-tab behavior.
  - Phase query now selects `deliveryState` and `deliveryUrl`; define the link contract as `/dash/org/{slug}/project/{projectPublicId}#phase-{phasePublicId}` for invoice links.

- **Bug Fixes**
  - Target highlight is instant (no fade), survives hover, and re-targets on hash changes; the previous target is cleared before applying the new one.

<sup>Written for commit a0a41a9358a71349cd2ddee02ac0d14c86db4eba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/craftlions/website/pull/274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

