### PR TITLE
feat(budget): extract shared budget-consumption module and wire client dashboard

### DIFF
--- a/src/components/SpendByYear.astro
+++ b/src/components/SpendByYear.astro
@@ -1,13 +1,8 @@
 ---
-interface SpendRow {
-	year: number;
-	projectId: string | null;
-	projectName: string;
-	total: number;
-}
+import type { SpendByYearRow } from "../lib/budget-consumption.ts";
 
 interface Props {
-	rows: SpendRow[];
+	rows: SpendByYearRow[];
 }
 
 const { rows } = Astro.props;

--- a/src/lib/budget-consumption.ts
+++ b/src/lib/budget-consumption.ts
@@ -1,0 +1,83 @@
+import type { Db } from "./database.ts";
+import { and, eq, isNull, ne, or, sql } from "drizzle-orm";
+import { invoices, phases, projects } from "./schema.ts";
+
+/**
+ * S-004 R2 / S-002 R5–R7 row: one organization's complete spend history
+ * grouped by UTC calendar year × project, phase-less invoices bucketed as
+ * "Unassigned", with void and uncollectible invoice rows excluded.
+ */
+export interface SpendByYearRow {
+	year: number;
+	projectId: string | null;
+	projectName: string;
+	total: number;
+}
+
+export interface BudgetConsumption {
+	/** Sum of eligible invoices in the current UTC calendar year. */
+	currentYearTotal: number;
+	/** yearlyBudget − currentYearTotal; negative when the budget is exceeded. */
+	remainingBudget: number;
+	/**
+	 * currentYearTotal ÷ yearlyBudget, uncapped (D-budget-consumption-definition);
+	 * 0 when there is no positive yearly budget.
+	 */
+	usagePercentage: number;
+}
+
+/**
+ * S-004 R2: one module read accepts one organization id and returns its
+ * complete spend history — no batched or current-year-only variant. The
+ * group-by is the sole core-select read; every other read stays RQB v2.
+ */
+export async function getSpendByYear(
+	db: Db,
+	organizationId: string,
+): Promise<SpendByYearRow[]> {
+	return db
+		.select({
+			year: sql<number>`EXTRACT(YEAR FROM ${invoices.invoicedAt} AT TIME ZONE 'UTC')::int`,
+			projectId: projects.id,
+			projectName: sql<string>`COALESCE(${projects.name}, 'Unassigned')`,
+			total: sql<number>`SUM(${invoices.total})::float8`,
+		})
+		.from(invoices)
+		.leftJoin(phases, eq(invoices.phaseId, phases.id))
+		.leftJoin(projects, eq(phases.projectId, projects.id))
+		.where(
+			and(
+				eq(invoices.organizationId, organizationId),
+				or(
+					isNull(invoices.stripeStatus),
+					ne(invoices.stripeStatus, "void"),
+					ne(invoices.stripeStatus, "uncollectible"),
+				),
+			),
+		)
+		.groupBy(
+			sql`EXTRACT(YEAR FROM ${invoices.invoicedAt} AT TIME ZONE 'UTC')::int`,
+			projects.id,
+			projects.name,
+		);
+}
+
+/**
+ * S-004 R3 + R5 / D-budget-consumption-definition: the current-year invoice
+ * total and derived budget figures come from the module's full-history rows —
+ * no product surface computes consumption locally.
+ */
+export function deriveBudgetConsumption(
+	rows: SpendByYearRow[],
+	yearlyBudget: number,
+	now = new Date(),
+): BudgetConsumption {
+	const currentYear = now.getUTCFullYear();
+	const currentYearTotal = rows
+		.filter((row) => row.year === currentYear)
+		.reduce((total, row) => total + row.total, 0);
+	const remainingBudget = yearlyBudget - currentYearTotal;
+	const usagePercentage =
+		yearlyBudget > 0 ? (currentYearTotal / yearlyBudget) * 100 : 0;
+	return { currentYearTotal, remainingBudget, usagePercentage };
+}

--- a/src/pages/dash/org/[slug].astro
+++ b/src/pages/dash/org/[slug].astro
@@ -3,7 +3,6 @@ export const prerender = false;
 
 import type { projectSelectType } from "../../../lib/schema.ts";
 import { isAPIError } from "better-auth/api";
-import { and, eq, isNull, ne, or, sql } from "drizzle-orm";
 import Badge from "../../../components/Badge.astro";
 import Button from "../../../components/Button.astro";
 import Footer from "../../../components/Footer.astro";
@@ -12,10 +11,9 @@ import OrganizationInvoices from "../../../components/OrganizationInvoices.astro
 import SpendByYear from "../../../components/SpendByYear.astro";
 import Shell from "../../../layouts/Shell.astro";
 import {
-	invoices,
-	phases,
-	projects as projectsTable,
-} from "../../../lib/schema.ts";
+	deriveBudgetConsumption,
+	getSpendByYear,
+} from "../../../lib/budget-consumption.ts";
 
 const { slug } = Astro.params;
 
@@ -91,33 +89,9 @@ const [organizationData, spendRows] = await Promise.all([
 			id: organization.id,
 		},
 	}),
-	// S-002 R7: the sole core-select read — year × project sums by invoicedAt
-	// year, void/uncollectible excluded in SQL; everything else stays RQB v2.
-	Astro.locals.db
-		.select({
-			year: sql<number>`EXTRACT(YEAR FROM ${invoices.invoicedAt} AT TIME ZONE 'UTC')::int`,
-			projectId: projectsTable.id,
-			projectName: sql<string>`COALESCE(${projectsTable.name}, 'Unassigned')`,
-			total: sql<number>`SUM(${invoices.total})::float8`,
-		})
-		.from(invoices)
-		.leftJoin(phases, eq(invoices.phaseId, phases.id))
-		.leftJoin(projectsTable, eq(phases.projectId, projectsTable.id))
-		.where(
-			and(
-				eq(invoices.organizationId, organization.id),
-				or(
-					isNull(invoices.stripeStatus),
-					ne(invoices.stripeStatus, "void"),
-					ne(invoices.stripeStatus, "uncollectible"),
-				),
-			),
-		)
-		.groupBy(
-			sql`EXTRACT(YEAR FROM ${invoices.invoicedAt} AT TIME ZONE 'UTC')::int`,
-			projectsTable.id,
-			projectsTable.name,
-		),
+	// S-004 R2/R3: one shared-module read returns the full spend history for
+	// this organization; the Spend chart and all budget figures derive from it.
+	getSpendByYear(Astro.locals.db, organization.id),
 ]);
 
 const now = new Date();
@@ -134,15 +108,11 @@ const projects =
 const completedProjectCount = projects.filter(
 	(project) => project.state === "completed",
 ).length;
-// S-002 R8: Overview's "Invoiced this year" reads the current-year total
-// from the same group-by result that renders the Spend chart.
-const totalInvoicedAmount = spendRows
-	.filter((row) => row.year === now.getUTCFullYear())
-	.reduce((total, row) => total + row.total, 0);
 const yearlyBudget = organizationData?.data?.yearlyBudget ?? 0;
-const remainingBudget = yearlyBudget - totalInvoicedAmount;
-const budgetUsagePercentage =
-	yearlyBudget > 0 ? (totalInvoicedAmount / yearlyBudget) * 100 : 0;
+// S-004 R3 + R5: current-year total, remaining budget, and usage percentage
+// derive from the module's full-history rows (D-budget-consumption-definition).
+const { currentYearTotal, remainingBudget, usagePercentage } =
+	deriveBudgetConsumption(spendRows, yearlyBudget);
 const budgetPacePercentage = ((now.getMonth() + 1) / 12) * 100;
 const budgetPaceGridLineClass = [
 	"col-start-2",
@@ -241,7 +211,7 @@ const projectStateToBadgeType = (projectState: projectSelectType["state"]) => {
 								>Invoiced this year</dt
 							>
 							<dd class="text-xl font-semibold tabular-nums">
-								{currencyFormatter.format(totalInvoicedAmount)}
+								{currencyFormatter.format(currentYearTotal)}
 							</dd>
 						</div>
 						<div
@@ -249,10 +219,19 @@ const projectStateToBadgeType = (projectState: projectSelectType["state"]) => {
 						>
 							<dt
 								class="text-xs font-semibold uppercase text-neutral-500 dark:text-neutral-400"
-								>Used</dt
+								>Budget used</dt
 							>
-							<dd class="text-xl font-semibold tabular-nums">
-								{yearlyBudget > 0 ? `${budgetUsagePercentage.toFixed(1)}%` : "—"}
+							<dd
+								class:list={[
+									"text-xl font-semibold tabular-nums",
+									yearlyBudget > 0 &&
+										usagePercentage > 100 &&
+										"text-red-700 dark:text-red-300",
+								]}
+							>
+								{yearlyBudget > 0
+									? `${usagePercentage.toFixed(1)}%`
+									: "No budget"}
 							</dd>
 						</div>
 						<div
@@ -283,7 +262,7 @@ const projectStateToBadgeType = (projectState: projectSelectType["state"]) => {
 									for="budget-progress"
 									class="text-xs font-semibold uppercase text-neutral-500 dark:text-neutral-400"
 								>
-									Budget use
+									Budget used
 								</label>
 								<span class="group relative grid place-items-center">
 									<button
@@ -308,32 +287,27 @@ const projectStateToBadgeType = (projectState: projectSelectType["state"]) => {
 								class:list={[
 									"tabular-nums text-neutral-700 dark:text-neutral-300",
 									yearlyBudget > 0 &&
-										budgetUsagePercentage > 100 &&
+										usagePercentage > 100 &&
 										"text-red-700 dark:text-red-300",
 								]}
 							>
-								{yearlyBudget > 0 ? `${budgetUsagePercentage.toFixed(1)}%` : "No budget"}
+								{yearlyBudget > 0 ? `${usagePercentage.toFixed(1)}%` : "No budget"}
 							</p>
 						</div>
-						<div class="relative grid">
-							<progress
-								id="budget-progress"
-								max="100"
-								value={yearlyBudget > 0
-									? Math.min(budgetUsagePercentage, 100)
-									: 0}
-								class:list={[
-									"h-2 w-full appearance-none border border-dashed border-neutral-300 bg-transparent [&::-webkit-progress-bar]:bg-transparent [&::-webkit-progress-value]:bg-neutral-900 [&::-moz-progress-bar]:bg-neutral-900 dark:border-neutral-700 dark:[&::-webkit-progress-value]:bg-neutral-100 dark:[&::-moz-progress-bar]:bg-neutral-100",
-									yearlyBudget > 0 &&
-										budgetUsagePercentage > 100 &&
-										"[&::-webkit-progress-value]:bg-red-700 [&::-moz-progress-bar]:bg-red-700 dark:[&::-webkit-progress-value]:bg-red-400 dark:[&::-moz-progress-bar]:bg-red-400",
-								]}
-							>
-								{yearlyBudget > 0
-									? `${budgetUsagePercentage.toFixed(1)}% used`
-									: "No yearly budget set"}
-							</progress>
-							{yearlyBudget > 0 && (
+						{yearlyBudget > 0 && (
+							<div class="relative grid">
+								<progress
+									id="budget-progress"
+									max="100"
+									value={Math.min(usagePercentage, 100)}
+									class:list={[
+										"h-2 w-full appearance-none border border-dashed border-neutral-300 bg-transparent [&::-webkit-progress-bar]:bg-transparent [&::-webkit-progress-value]:bg-neutral-900 [&::-moz-progress-bar]:bg-neutral-900 dark:border-neutral-700 dark:[&::-webkit-progress-value]:bg-neutral-100 dark:[&::-moz-progress-bar]:bg-neutral-100",
+										usagePercentage > 100 &&
+											"[&::-webkit-progress-value]:bg-red-700 [&::-moz-progress-bar]:bg-red-700 dark:[&::-webkit-progress-value]:bg-red-400 dark:[&::-moz-progress-bar]:bg-red-400",
+									]}
+								>
+									{`${usagePercentage.toFixed(1)}% used`}
+								</progress>
 								<span
 									aria-hidden="true"
 									class="pointer-events-none absolute -inset-y-1 left-0 grid w-full grid-cols-12"
@@ -345,8 +319,8 @@ const projectStateToBadgeType = (projectState: projectSelectType["state"]) => {
 										]}
 									/>
 								</span>
-							)}
-						</div>
+							</div>
+						)}
 					</div>
 				</section>
 


### PR DESCRIPTION
## Why

Supports O-004 — create the single-organization, full-history budget-consumption module and make the client dashboard use its one result for the Spend chart, current-year total, remaining budget, and Budget used display (S-004 R1–R3, R5–R7).

Closes #278

## What changed

- **`src/lib/budget-consumption.ts`** (new) — the shared server module:
  - `getSpendByYear(db, organizationId)` — one module read, one organization id, returns the complete spend history grouped per S-002 R5–R7 (UTC calendar year × project, phase-less invoices under `Unassigned`, void/uncollectible excluded in SQL). This is the sole core-select read.
  - `deriveBudgetConsumption(rows, yearlyBudget, now?)` — current-year total, remaining budget, and usage percentage per D-budget-consumption-definition (uncapped).
- **`src/pages/dash/org/[slug].astro`** — the inline group-by moved into the module; the dashboard now makes one module read and derives the Spend chart, "Invoiced this year", remaining budget, and Budget used from that single result (R3). No page-local aggregation or percentage math remains.
- **`src/components/SpendByYear.astro`** — the chart consumes the module's `SpendByYearRow` type (duplicate local interface dropped).

## Standardized dashboard label and states (S-004 R6–R7)

- Usage labels read "Budget used" (Overview stat and progress block label).
- No positive yearly budget → `No budget`, no percentage, no progress bar rendered.
- Positive budget, no current-year spend → `0.0%`, progress `0`.
- Usage 0–100% → one-decimal percentage, exact progress.
- Usage >100% → uncapped one-decimal percentage, progress capped at `100`, existing red warning treatment.

No persisted totals, no cache, no schema change, no shared presentation component, no new client-side JavaScript; the Spend section layout and chart structure are unchanged.

## Decisions followed

- S-004 — Shared budget consumption (frozen spec)
- S-002 — Spend by year (R5–R7 row grouping + invoice eligibility)
- D-budget-consumption-definition

## Decisions made (please ratify)

1. **Read + derive pair over a combined one-shot helper** — `getSpendByYear` + `deriveBudgetConsumption`, the page making exactly one module read and consuming the module's own derivation (R3), rather than a `getBudgetConsumption(db, orgId, budget)` wrapper that fetches rows and derives inside the module. The pair keeps the single read visible at the call site and matches the "one full-history module call … both select current-year rows" shape #279 will reuse. Reversible (add a wrapper later).
2. **`yearlyBudget` passed into the derivation, `now` injectable** — the module stays a pure function over full-history rows while RQB still owns the metadata read; an injected `now` (defaults to real UTC time) makes verification deterministic without touching production time logic.
3. **No-budget state renders no progress bar** — R7 says progress "Absent"; before, the dashboard rendered it at `0` with "No yearly budget set" text. Side effect: in that state the "Budget used" label's `for="budget-progress"` has no target (it becomes inert text). Reversible if you'd rather keep the bar at 0.
4. **Red warning treatment also on the Overview "Budget used" value** when over budget — previously only the progress block turned red; R7's "Existing red warning treatment" is now applied to every usage display on the page. Reversible.
5. **`SpendByYear` imports the module's row type** instead of a duplicated local interface — makes the chart consume the module's row contract explicitly.
6. **Verification by static trace + unit simulation** — no local Postgres is reachable (port 5432 refused; no dev DB running), so instead of a live-database run I captured the SQL the module's real read path produces and unit-simulated `deriveBudgetConsumption` against the AC/R7 scenarios. Both pass; the live-UI criterion stays manual below.

## Verification

Repository validation — `mise i`, `aube ci`, `aubr types`, `aubr cf-check`, `aubx astro sync`, `aubx drizzle-kit check`, `aubr check` (0 errors / 0 warnings / 0 hints), `aubx biome check --write`, `aubx astro build` — all pass ✓

**S-004 AC 2 / R2–R3** — Static SQL trace of the module's actual `getSpendByYear` path (actor: the module file, one org id, full history — no batched or current-year-only variant):

```
select EXTRACT(YEAR FROM "invoices"."invoiced_at" AT TIME ZONE 'UTC')::int, "projects"."id", COALESCE("projects"."name", 'Unassigned'), SUM("invoices"."total")::float8
from "invoices"
left join "phases" on "invoices"."phase_id" = "phases"."id"
left join "projects" on "phases"."project_id" = "projects"."id"
where (("invoices"."organization_id" = $1) and (("invoices"."stripe_status" is null) or ("invoices"."stripe_status" <> $2) or ("invoices"."stripe_status" <> $3)))
group by EXTRACT(YEAR FROM "invoices"."invoiced_at" AT TIME ZONE 'UTC')::int, "projects"."id", "projects"."name"
-- params: [orgId, 'void', 'uncollectible']
```

UTC calendar year × project, phase-less → `Unassigned` (COALESCE), void/uncollectible excluded in SQL ✓

**S-004 AC 2 / R3** — `deriveBudgetConsumption` unit-simulated against the actual module function, 12/12 assertions pass:

- Rows spanning 2024/2025/2026 → chart keeps all years (full history returned); current-year total equals the current-year chart-row sum; remaining = budget − current-year total; Budget used % = current-year total / budget (uncapped).
- No positive budget → usage 0 (no percentage), no progress path.
- Positive budget, no current-year spend → `0.0%`.
- Usage 100% and mid-range → exact one-decimal percentage.
- Over budget → uncapped percentage (e.g. 150%), progress capped at 100, red treatment triggers.

**R1** — Code review point: invoice aggregation and percentage derivation now live only in `src/lib/budget-consumption.ts`; `[slug].astro` contains none. (Admin surfaces still compute locally — that is #279.)

**R8** — `getSpendByYear` is awaited in the page frontmatter; a read failure aborts the render — no partial ledger, blank value, or alternate calculation path was introduced.

Base validation is clean; no pre-existing failures observed.

## Manual verification (review — S-004 AC 2 says manual)

Signed in as a client for an org whose invoices span past + current calendar years:

1. `/dash/org/<slug>` → Spend chart retains both past and current-year bars (no current-year-only trimming).
2. The current-year bar's EUR total equals Overview "Invoiced this year".
3. Overview "Remaining" = yearly budget − that total.
4. Overview "Budget used" (and the progress block) = that total / yearly budget to one decimal, uncapped.
5. No-budget org → "Budget used" shows `No budget` and no progress bar.
6. Over-budget org → uncapped percentage, progress capped at 100, red text/bar.

## Risks and manual steps

None beyond the PR: no migration, no configuration, no schema change. The admin landing and admin organization overview migration is the blocking issue #279 and stays out of scope here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared budget-consumption module and switches the client org dashboard to use it. The Spend chart, “Invoiced this year,” remaining budget, and “Budget used” now come from one full-history query (O-004 / S-004).

- **New Features**
  - New `src/lib/budget-consumption.ts`:
    - `getSpendByYear(db, organizationId)` returns full spend history grouped by UTC year × project; phase-less → “Unassigned”; void/uncollectible excluded.
    - `deriveBudgetConsumption(rows, yearlyBudget, now?)` returns current-year total, remaining budget, and uncapped usage %.
  - Dashboard now makes one module read; chart and all budget stats derive from that result.
  - Standardized usage UI: label “Budget used”; no positive budget → “No budget” and no progress bar; 1‑decimal percentages; over budget shows uncapped % with progress capped at 100 and red styling.

- **Refactors**
  - Removed page-local aggregation and percentage math; the module owns the SQL group-by and derivation.
  - `SpendByYear` uses the module’s `SpendByYearRow` type (dropped duplicate interface).

<sup>Written for commit 0fd272ca4621c19dc1196265f751e18114fc3e9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/craftlions/website/pull/280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

