### PR TITLE
feat(admin): adopt shared budget consumption across admin surfaces

### DIFF
--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -7,6 +7,10 @@ import Button from "../../components/Button.astro";
 import Footer from "../../components/Footer.astro";
 import Nav from "../../components/Nav.astro";
 import Shell from "../../layouts/Shell.astro";
+import {
+	deriveBudgetConsumption,
+	getSpendByYear,
+} from "../../lib/budget-consumption.ts";
 import { getUuidV7Date } from "../../lib/uuid.ts";
 
 const onboardResult = Astro.getActionResult(actions.onboardOrganization);
@@ -62,6 +66,16 @@ const organizations = await Astro.locals.db.query.organization.findMany({
 		name: "asc",
 	},
 });
+
+// S-004 R2/R4: one full-history module read per organization; deriveBudget
+// selects the current-year rows. Any read failure aborts this page render —
+// no partial ledger or fallback (R8).
+const organizationsWithSpend = await Promise.all(
+	organizations.map(async (organization) => ({
+		organization,
+		spendRows: await getSpendByYear(Astro.locals.db, organization.id),
+	})),
+);
 
 const now = new Date();
 const currencyFormatter = new Intl.NumberFormat("de-DE", {
@@ -151,7 +165,7 @@ const queue = organizations
 	)
 	.toSorted((a, b) => a.priority - b.priority || b.days - a.days);
 
-const ledger = organizations.map((organization) => {
+const ledger = organizationsWithSpend.map(({ organization, spendRows }) => {
 	const activeProjects = organization.projects.filter(
 		(project) => project.state === "active",
 	).length;
@@ -175,6 +189,11 @@ const ledger = organizations.map((organization) => {
 				phase.invoice.stripeDueAt &&
 				phase.invoice.stripeDueAt < now,
 		).length;
+	// S-004 R1/R5: budget usage is the shared module's current-year percentage
+	// (D-budget-consumption-definition, uncapped); null when there is no
+	// positive yearly budget (R7 "No budget").
+	const yearlyBudget = organization.data?.yearlyBudget ?? 0;
+	const { usagePercentage } = deriveBudgetConsumption(spendRows, yearlyBudget);
 
 	return {
 		...organization,
@@ -184,10 +203,7 @@ const ledger = organizations.map((organization) => {
 		planned,
 		submitted,
 		overdue,
-		budgetUsage:
-			organization.data?.yearlyBudget && organization.data.yearlyBudget > 0
-				? (openInvoices / organization.data.yearlyBudget) * 100
-				: null,
+		budgetUsage: yearlyBudget > 0 ? usagePercentage : null,
 	};
 });
 const outstandingTotal = ledger.reduce(
@@ -292,7 +308,7 @@ const overdueCount = queue.filter((item) => item.priority === 0).length;
 								<th class="px-4 py-3" scope="col">Client</th>
 								<th class="px-4 py-3" scope="col">Attention</th>
 								<th class="px-4 py-3" scope="col">Projects</th>
-								<th class="px-4 py-3" scope="col">Budget</th>
+								<th class="px-4 py-3" scope="col">Budget used</th>
 								<th class="px-4 py-3 text-right" scope="col">Open</th>
 							</tr>
 						</thead>

--- a/src/pages/admin/org/[id].astro
+++ b/src/pages/admin/org/[id].astro
@@ -12,6 +12,10 @@ import {
 } from "drizzle-orm";
 import AdminOrgShell from "../../../layouts/AdminOrgShell.astro";
 import {
+	deriveBudgetConsumption,
+	getSpendByYear,
+} from "../../../lib/budget-consumption.ts";
+import {
 	invoices,
 	member,
 	organizationMetadata,
@@ -33,15 +37,6 @@ const [organization] = await Astro.locals.db
 		id: organizationTable.id,
 		name: organizationTable.name,
 		yearlyBudget: organizationMetadata.yearlyBudget,
-		phaseCostTotal: scalar(
-			Astro.locals.db
-				.select({
-					value: sum(phases.cost),
-				})
-				.from(phases)
-				.innerJoin(projects, eq(phases.projectId, projects.id))
-				.where(eq(projects.organizationId, organizationTable.id)),
-		),
 		openInvoiceTotal: scalar(
 			Astro.locals.db
 				.select({
@@ -124,10 +119,17 @@ if (!organization) {
 	return Astro.redirect("/admin");
 }
 
-const budgetUsage =
-	organization.yearlyBudget && organization.yearlyBudget > 0
-		? (organization.phaseCostTotal / organization.yearlyBudget) * 100
-		: null;
+// S-004 R4: one full-history module read per organization; deriveBudget
+// selects the current-year rows. Any read failure aborts this page — no
+// fallback or alternate calculation (R8).
+const yearlyBudget = organization.yearlyBudget ?? 0;
+const { usagePercentage } = deriveBudgetConsumption(
+	await getSpendByYear(Astro.locals.db, id),
+	yearlyBudget,
+);
+// R7: "Budget used" shows a one-decimal uncapped percentage only when there
+// is a positive yearly budget; otherwise "No budget" with no percentage.
+const hasBudget = yearlyBudget > 0;
 const currencyFormatter = new Intl.NumberFormat("de-DE", {
 	style: "currency",
 	currency: "EUR",
@@ -171,8 +173,8 @@ const sections = [
 					>Budget used</dt
 				>
 				<dd
-					class:list={["text-xl font-semibold tabular-nums", budgetUsage !== null && budgetUsage > 100 && "text-red-700 dark:text-red-300"]}
-					>{budgetUsage === null ? "-" : `${budgetUsage.toFixed(1)}%`}</dd
+					class:list={["text-xl font-semibold tabular-nums", hasBudget && usagePercentage > 100 && "text-red-700 dark:text-red-300"]}
+					>{hasBudget ? `${usagePercentage.toFixed(1)}%` : "No budget"}</dd
 				>
 			</div>
 			<div class="grid gap-1">


### PR DESCRIPTION
## Why

Supports O-004 — move the admin landing page and admin organization overview onto the shared budget-consumption module so every product surface shows the same current-year result and states (S-004 R1, R4–R8; AC 1, 3–7).

Closes #279

## What changed

- **`src/pages/admin/index.astro`** (admin landing)
  - One full-history module read per organization (`getSpendByYear`, `Promise.all`) + the module's `deriveBudgetConsumption` for each — the "Budget used" column now comes from the shared module instead of the page-local `openInvoices / yearlyBudget` (open-invoice-based) calculation.
  - The Budget column header reads **"Budget used"** (R6).
  - R7 states: no positive yearly budget → `No budget` with no percentage or progress; otherwise one-decimal uncapped percentage, progress capped at 100, red warning over budget. Cell markup otherwise unchanged.
  - Any organization read failure rejects the `Promise.all` and aborts the page — never a partial ledger, blank value, or fallback (R8 / AC 7).
- **`src/pages/admin/org/[id].astro`** (admin organization overview)
  - One full-history module read per organization + the module's `deriveBudgetConsumption` for the "Budget used" stat.
  - Removed the page-local phase-cost calculation and the now-dead `phaseCostTotal` scalar from the select.
  - R7 states: no positive yearly budget → `No budget` (was `-`), no percentage; otherwise one-decimal uncapped percentage with the existing red treatment over budget. Layout unchanged.
- Open-invoice/outstanding totals (landing "Open"/"Outstanding", overview "Open invoices", the queue) are worklist metrics, not budget usage — they stay as they were.

The module contract from #278 is untouched (invoice eligibility and budget math unchanged). No shared presentation component, cache, persistence, schema change, or client-side JavaScript.

## Decisions followed

- S-004 — Shared budget consumption (frozen spec)
- S-002 — Spend by year (R5–R7 row grouping + invoice eligibility, unchanged)
- D-budget-consumption-definition

## Decisions made (please ratify)

1. **Admin landing column header renamed "Budget" → "Budget used"** — R6 says every user-facing usage label reads "Budget used", and AC 5 says every surface labels the metric Budget used. Reversible (rename back).
2. **Open-invoice / Outstanding totals kept page-local** — they are worklist/outstanding metrics, not budget consumption; only the budget-percentage derivation moved to the module (R1 targets aggregation + percentage derivation). Flagged so review can confirm the boundary.
3. **Admin overview "Budget used" now shows `No budget` instead of `-`** when there is no positive yearly budget (AC 5 / R7) and the red treatment now keys off the module's percentage.
4. **Verification-by-substitute** follows the approach ratified with #280's merge: no local Postgres is reachable (port 5432 refused), so I executed the module's real read/derive paths with a static SQL trace + a unit simulation covering AC 3–7, and ran the full repo validation suite. Nothing verification-related is committed.

## Verification

Repository validation — `aubx drizzle-kit check`, `aubr types`, `aubr cf-check`, `aubx astro sync`, `aubr check` (0 errors / 0 warnings / 0 hints), `aubx biome check --write`, `aubx astro build` — all pass ✓

**AC 1 / R1** — grep of both admin pages: the only budget-percentage derivation is `deriveBudgetConsumption(spendRows, yearlyBudget)` from `../../lib/budget-consumption.ts` (or `../../../`); the landing's `openInvoices / yearlyBudget` calculation and the overview's `phaseCostTotal / yearlyBudget` calculation and its `phaseCostTotal` scalar are gone. Client dashboard (#280), admin landing, and admin overview now all consume the shared module ✓

**AC 3 / AC 4 / AC 5 / AC 6** — unit simulation against the actual module function, 11/11 checks pass:

- **AC 3** — one fixture of rows (historical 2024/2025 + current-year 2026, incl. a phase-less Unassigned row) fed through the same `deriveBudgetConsumption(rows, budget)` all three surfaces call → identical percentage (dashboard === admin landing === admin overview) despite historical spend ✓
- **AC 4** — current-year total equals the sum of eligible current-year rows incl. the phase-less Unassigned row; excluded-status rows are removed by the module read's SQL (traced below), so they never reach any surface ✓
- **AC 5** — `yearlyBudget = 0` → no derived percentage; landing renders `No budget` with no progress, overview renders `No budget` with no percentage ✓
- **AC 6** — over-budget fixture → uncapped one-decimal percentage (`150.0%`), progress capped at 100, red warning trigger ✓

**AC 7 / R8** — one failing organization read in the landing's `Promise.all` rejects the whole read (simulated) — the page aborts instead of rendering a partial ledger; the page code has no try/catch or fallback around the module reads ✓

**Module contract unchanged (#278)** — static SQL trace of `getSpendByYear` still shows one org id (`$1`), full history, UTC calendar year × project grouping, `Unassigned` COALESCE bucket, and `void`/`uncollectible` excluded in SQL ✓

Base validation is clean; no pre-existing failures observed.

## Manual verification (review — S-004 AC 3–7 are manual)

Signed in as an admin:

1. **AC 3** — same organization on `/admin`, `/admin/org/<id>`, and the client dashboard (`/dash/org/<slug>`) → identical "Budget used" percentage despite historical spend.
2. **AC 4** — org with a current-year phase-less invoice → counted (Unassigned row) on all three; org with a void or uncollectible invoice → excluded everywhere.
3. **AC 5** — org with no positive yearly budget: admin landing cell shows `No budget` (no percentage, no progress), admin overview shows `No budget`, client dashboard shows `No budget` with no progress.
4. **AC 6** — org over budget: uncapped one-decimal percentage everywhere, progress capped at 100 (landing + dashboard), red warning treatment.
5. **AC 7** — force one org's spend read to fail during `/admin` render (e.g., temporarily break the module's SQL or point at an unavailable DB) → the landing fails instead of showing a partial ledger.

## Risks and manual steps

None beyond the PR: no migration, no configuration, no schema change. Admin layouts are preserved. Chart/spec module contract unchanged.

<!-- This PR was produced unattended per the work.md skill; decisions flagged for review in "Decisions made". -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the admin landing and org overview to the shared budget-consumption module so all surfaces show the same current‑year “Budget used”. Aligns with O‑004/S‑004 and closes #279.

- **Refactors**
  - Use `getSpendByYear` + `deriveBudgetConsumption` per org; remove local calculations and the `phaseCostTotal` scalar.
  - Standardize UI: header is “Budget used”; one‑decimal uncapped percentage; red when >100; “No budget” when yearly budget ≤ 0; progress capped at 100.
  - Abort admin landing on any org spend read failure (no partial ledger).
  - Keep open/outstanding totals unchanged.

<sup>Written for commit 189c413406d9ed63eae89bf7cb111070e0a2e2df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/craftlions/website/pull/281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

